### PR TITLE
feat: add enhanced debug logging for bot owner permissions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -107,14 +107,14 @@ async function startBot() {
 
     await client.login(process.env.BOT_TOKEN);
     log.info(`Logged in. Version ${VERSION}`);
-    
+
     // Log bot owner configuration for debugging
     const ownerId = config.get<string>('owner');
     log.info(`=== BOT OWNER CONFIGURATION ===`);
     log.info(`Configured owner ID: ${ownerId}`);
     log.info(`Owner ID type: ${typeof ownerId}`);
     log.info(`===================================`);
-    
+
     // Send owner config to #deploy channel
     try {
         const deployChannelId = '847239885146333215'; // #deploy channel

--- a/index.ts
+++ b/index.ts
@@ -107,6 +107,29 @@ async function startBot() {
 
     await client.login(process.env.BOT_TOKEN);
     log.info(`Logged in. Version ${VERSION}`);
+    
+    // Log bot owner configuration for debugging
+    const ownerId = config.get<string>('owner');
+    log.info(`=== BOT OWNER CONFIGURATION ===`);
+    log.info(`Configured owner ID: ${ownerId}`);
+    log.info(`Owner ID type: ${typeof ownerId}`);
+    log.info(`===================================`);
+    
+    // Send owner config to #deploy channel
+    try {
+        const deployChannelId = '847239885146333215'; // #deploy channel
+        const deployChannel = await client.channels.fetch(deployChannelId);
+        if (deployChannel?.isTextBased() && 'send' in deployChannel) {
+            await deployChannel.send(`🚀 **Bot Deployed**\n` +
+                `**Version:** ${VERSION}\n` +
+                `**Configured Owner ID:** ${ownerId}\n` +
+                `**Owner ID Type:** ${typeof ownerId}\n` +
+                `**Node Environment:** ${process.env.NODE_ENV}\n` +
+                `**Timestamp:** ${new Date().toISOString()}`);
+        }
+    } catch (error) {
+        log.error('Failed to send deploy message:', error);
+    }
 
     // Initialize motivational scheduler after successful login
     motivationalScheduler = new MotivationalScheduler(client, context);

--- a/src/commands/join.test.ts
+++ b/src/commands/join.test.ts
@@ -71,7 +71,11 @@ describe('join command', () => {
         await joinCommand.execute(mockInteraction, mockContext);
 
         expect(mockInteraction.reply).toHaveBeenCalledWith({
-            content: '❌ This command is restricted to the bot owner only.',
+            content: `❌ This command is restricted to the bot owner only.\n` +
+                    `**Debug Info:**\n` +
+                    `Your ID: \`not-owner\`\n` +
+                    `Owner ID: \`test-owner-id\`\n` +
+                    `Match: ❌`,
             ephemeral: true,
         });
     });

--- a/src/commands/join.ts
+++ b/src/commands/join.ts
@@ -12,7 +12,7 @@ export default {
 
         try {
             // Check if user is bot owner
-            await checkOwnerPermission(interaction);
+            await checkOwnerPermission(interaction, context);
 
             // Get voice service from context
             if (!context.voiceService) {

--- a/src/commands/leave.test.ts
+++ b/src/commands/leave.test.ts
@@ -56,7 +56,11 @@ describe('leave command', () => {
         await leaveCommand.execute(mockInteraction, mockContext);
 
         expect(mockInteraction.reply).toHaveBeenCalledWith({
-            content: '❌ This command is restricted to the bot owner only.',
+            content: `❌ This command is restricted to the bot owner only.\n` +
+                    `**Debug Info:**\n` +
+                    `Your ID: \`not-owner\`\n` +
+                    `Owner ID: \`test-owner-id\`\n` +
+                    `Match: ❌`,
             ephemeral: true,
         });
     });

--- a/src/commands/leave.ts
+++ b/src/commands/leave.ts
@@ -12,7 +12,7 @@ export default {
 
         try {
             // Check if user is bot owner
-            await checkOwnerPermission(interaction);
+            await checkOwnerPermission(interaction, context);
 
             // Get voice service from context
             if (!context.voiceService) {

--- a/src/commands/speak.test.ts
+++ b/src/commands/speak.test.ts
@@ -75,7 +75,11 @@ describe('speak command', () => {
         await speakCommand.execute(mockInteraction, mockContext);
 
         expect(mockInteraction.reply).toHaveBeenCalledWith({
-            content: '❌ This command is restricted to the bot owner only.',
+            content: `❌ This command is restricted to the bot owner only.\n` +
+                    `**Debug Info:**\n` +
+                    `Your ID: \`not-owner\`\n` +
+                    `Owner ID: \`test-owner-id\`\n` +
+                    `Match: ❌`,
             ephemeral: true,
         });
     });

--- a/src/commands/speak.ts
+++ b/src/commands/speak.ts
@@ -36,7 +36,7 @@ export default {
 
         try {
             // Check if user is bot owner
-            await checkOwnerPermission(interaction);
+            await checkOwnerPermission(interaction, context);
 
             // Get voice service from context
             if (!context.voiceService) {

--- a/src/commands/tts-config.test.ts
+++ b/src/commands/tts-config.test.ts
@@ -68,7 +68,11 @@ describe('tts-config command', () => {
         await ttsConfigCommand.execute(mockInteraction, mockContext);
 
         expect(mockInteraction.reply).toHaveBeenCalledWith({
-            content: '❌ This command is restricted to the bot owner only.',
+            content: `❌ This command is restricted to the bot owner only.\n` +
+                    `**Debug Info:**\n` +
+                    `Your ID: \`not-owner\`\n` +
+                    `Owner ID: \`test-owner-id\`\n` +
+                    `Match: ❌`,
             ephemeral: true,
         });
     });

--- a/src/commands/tts-config.ts
+++ b/src/commands/tts-config.ts
@@ -149,7 +149,7 @@ export default {
 
         try {
             // Check if user is bot owner
-            await checkOwnerPermission(interaction);
+            await checkOwnerPermission(interaction, context);
 
             const subcommand = interaction.options.getSubcommand();
 

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -11,12 +11,40 @@ export function isOwner(userId: string): boolean {
 /**
  * Check owner permission and reply with error if unauthorized
  * @param interaction Discord interaction object
+ * @param context Context object for logging (optional)
  * @throws Error if user is not the bot owner
  */
-export async function checkOwnerPermission(interaction: any): Promise<void> {
-    if (!isOwner(interaction.user.id)) {
+export async function checkOwnerPermission(interaction: any, context?: any): Promise<void> {
+    const ownerId = config.get<string>('owner');
+    const userId = interaction.user.id;
+    const isUserOwner = userId === ownerId;
+    
+    // Enhanced logging for debugging
+    const logData = {
+        command: interaction.commandName,
+        userId: userId,
+        username: interaction.user.username,
+        userIdType: typeof userId,
+        configuredOwnerId: ownerId,
+        ownerIdType: typeof ownerId,
+        isOwner: isUserOwner,
+        exactMatch: userId === ownerId,
+        comparison: `"${userId}" === "${ownerId}"`,
+    };
+    
+    if (context?.log) {
+        context.log.info('=== OWNER PERMISSION CHECK ===', logData);
+    } else {
+        console.log('=== OWNER PERMISSION CHECK ===', logData);
+    }
+    
+    if (!isUserOwner) {
         await interaction.reply({
-            content: '❌ This command is restricted to the bot owner only.',
+            content: `❌ This command is restricted to the bot owner only.\n` +
+                    `**Debug Info:**\n` +
+                    `Your ID: \`${userId}\`\n` +
+                    `Owner ID: \`${ownerId}\`\n` +
+                    `Match: ${isUserOwner ? '✅' : '❌'}`,
             ephemeral: true,
         });
         throw new Error('Unauthorized: User is not bot owner');

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -18,7 +18,7 @@ export async function checkOwnerPermission(interaction: any, context?: any): Pro
     const ownerId = config.get<string>('owner');
     const userId = interaction.user.id;
     const isUserOwner = userId === ownerId;
-    
+
     // Enhanced logging for debugging
     const logData = {
         command: interaction.commandName,
@@ -31,13 +31,11 @@ export async function checkOwnerPermission(interaction: any, context?: any): Pro
         exactMatch: userId === ownerId,
         comparison: `"${userId}" === "${ownerId}"`,
     };
-    
+
     if (context?.log) {
         context.log.info('=== OWNER PERMISSION CHECK ===', logData);
-    } else {
-        console.log('=== OWNER PERMISSION CHECK ===', logData);
     }
-    
+
     if (!isUserOwner) {
         await interaction.reply({
             content: `❌ This command is restricted to the bot owner only.\n` +


### PR DESCRIPTION
## Summary
Adds comprehensive debug logging to troubleshoot the ongoing issue where user 145679133257498624 is being rejected by owner permission checks despite being correctly configured.

## Changes Made

### 🚀 Bot Startup Logging
- **Deploy Channel Notifications**: Bot now posts startup info to #deploy channel including:
  - Version number
  - Configured owner ID and data type  
  - Node environment
  - Deployment timestamp

### 🔍 Enhanced Permission Debugging
- **Detailed Permission Logging**: `checkOwnerPermission` now logs comprehensive debug info:
  - User ID vs configured owner ID comparison
  - Data types for both IDs (to catch type mismatches)
  - Exact string comparison details
  
- **User-Facing Debug Info**: Permission error messages now include:
  - User's actual ID
  - Configured owner ID
  - Visual match indicator

### 🧪 Test Updates
- Updated all TTS command tests to expect new debug message format
- All tests passing with enhanced error messages

## Context
This addresses the permission issue where the `/join` command fails with "restricted to bot owner only" even though:
- User ID 145679133257498624 is correctly configured in `config/default.yaml`
- Previous deployments should have included the user

## Testing
- ✅ All unit tests pass
- ✅ Lint checks clean
- ✅ TypeScript compilation successful
- ✅ Successfully deployed to production

The enhanced logging will help identify whether this is:
- A configuration loading issue
- A data type mismatch (string vs number)
- A deployment/restart issue
- Something else entirely

🤖 Generated with [Claude Code](https://claude.ai/code)