### PR TITLE
fix: add owner logging to ready event where deploy message is sent

### DIFF
--- a/events/ready.ts
+++ b/events/ready.ts
@@ -21,7 +21,7 @@ const clientReadyEvent: BotEvent = {
 
         // Get owner configuration for deployment message
         const ownerId = config.get<string>('owner');
-        
+
         // Log owner configuration to application logs
         log.info('=== BOT OWNER CONFIGURATION (READY EVENT) ===');
         log.info(`Configured Owner ID: ${ownerId}`);

--- a/events/ready.ts
+++ b/events/ready.ts
@@ -2,6 +2,7 @@ import { Client, ChannelType, Events, EmbedBuilder, TextChannel } from 'discord.
 import { Context, BotEvent } from '../src/utils/types';
 import server from '../src/lib/server';
 import { stripIndent } from 'common-tags';
+import config from 'config';
 
 const clientReadyEvent: BotEvent = {
     name: Events.ClientReady,
@@ -18,8 +19,24 @@ const clientReadyEvent: BotEvent = {
             chan.type === ChannelType.GuildText && chan.name === 'deploy',
         ) as TextChannel | undefined;
 
+        // Get owner configuration for deployment message
+        const ownerId = config.get<string>('owner');
+        
+        // Log owner configuration to application logs
+        log.info('=== BOT OWNER CONFIGURATION (READY EVENT) ===');
+        log.info(`Configured Owner ID: ${ownerId}`);
+        log.info(`Owner ID Type: ${typeof ownerId}`);
+        log.info(`Environment: ${process.env.NODE_ENV}`);
+        log.info('=============================================');
+
         if (devChannel) {
-            await devChannel.send(`Successfully deployed on ${process.env.NODE_ENV}. Version ${VERSION}.`);
+            await devChannel.send(stripIndent`
+                🚀 **Successfully deployed on ${process.env.NODE_ENV}**
+                **Version:** ${VERSION}
+                **Bot Owner ID:** ${ownerId}
+                **Owner ID Type:** ${typeof ownerId}
+                **Timestamp:** ${new Date().toISOString()}
+            `);
         } else {
             log.error("Failed to find 'deploy' channel.");
         }


### PR DESCRIPTION
## Problem
The previous owner logging was added to `index.ts` (startup phase) but the actual "Successfully deployed" message visible in #deploy channel is sent from `events/ready.ts` (when bot connects to Discord). This meant the deploy message was missing the critical owner configuration info.

## Root Cause
- `index.ts`: Handles bot startup and service initialization
- `events/ready.ts`: Handles Discord connection and sends deploy message to #deploy channel
- Owner logging was in the wrong place!

## Solution
Added comprehensive owner configuration logging to `events/ready.ts` where the actual deploy message is sent.

## Changes Made

### 📍 Fixed Location
- **Added owner logging to `events/ready.ts`** (where deploy message actually sends)
- **Enhanced the #deploy channel message** with owner configuration  
- **Added application logging** for troubleshooting

### 📋 Deploy Message Now Includes
```
🚀 Successfully deployed on production
Version: [version]  
Bot Owner ID: [actual loaded ID]
Owner ID Type: [string/number]
Timestamp: [timestamp]
```

### 🔍 Application Logs Include
```
=== BOT OWNER CONFIGURATION (READY EVENT) ===
Configured Owner ID: [actual loaded ID] 
Owner ID Type: [string/number]
Environment: [environment]
=============================================
```

## Expected Outcome
After deployment, the #deploy channel will clearly show what owner ID the bot loaded, helping us identify why it's loading `145679133257498620` instead of the correct `145679133257498624`.

## Context
This addresses the owner permission issue where:
- User ID: `145679133257498624` (correct)
- Bot loaded ID: `145679133257498620` (wrong - last digit differs)
- `/join` command fails due to owner mismatch

🤖 Generated with [Claude Code](https://claude.ai/code)