### PR TITLE
HOTFIX: Fix owner ID precision loss in JavaScript

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -15,4 +15,4 @@ database:
 webhook:
   port: 8080
 
-owner: 145679133257498624
+owner: "145679133257498624"


### PR DESCRIPTION
## 🚨 Critical Production Hotfix

**Issue**: Owner ID comparison failing due to JavaScript number precision loss.

## Root Cause Analysis

**Problem**: Large Discord IDs exceed `Number.MAX_SAFE_INTEGER` causing precision loss during YAML parsing:

```yaml
# YAML file (config/default.yaml)
owner: 145679133257498624  # Original correct value

# JavaScript parsing result  
owner: 145679133257498620  # Lost 4 digits due to precision limit
```

**Evidence from Sentry logs**:
- Original YAML: `145679133257498624` 
- Parsed value: `145679133257498620`
- User trying /join: `145679133257498624`
- Result: Owner ID mismatch → Access denied

## Solution

Store owner ID as **string** in YAML to prevent precision loss:

```yaml
# Before (number - loses precision)
owner: 145679133257498624

# After (string - preserves exact value) 
owner: "145679133257498624"
```

## Technical Details

- `Number.MAX_SAFE_INTEGER` = `9,007,199,254,740,991`
- Discord ID `145,679,133,257,498,624` > MAX_SAFE_INTEGER
- JavaScript rounds to nearest representable value
- String parsing preserves exact digits

## Production Impact

**Before**: `/join` command fails for legitimate bot owner  
**After**: Owner authentication works correctly

## Testing

```javascript
// Verify the issue
console.log(145679133257498624);     // 145679133257498620 (precision lost)
console.log("145679133257498624");   // "145679133257498624" (exact)
```

This is a **critical production issue** affecting bot owner authentication.