### PR TITLE
fix: add DAVE protocol dependency for voice connections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "@hapi/hapi": "^21.3.2",
                 "@sentry/node": "^10.8.0",
                 "@sentry/profiling-node": "^10.8.0",
+                "@snazzah/davey": "^0.1.6",
                 "@types/jimp": "^0.2.1",
                 "@types/node-cron": "^3.0.11",
                 "axios": "^1.11.0",
@@ -738,6 +739,37 @@
             },
             "funding": {
                 "url": "https://github.com/discordjs/discord.js?sponsor"
+            }
+        },
+        "node_modules/@emnapi/core": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
+            "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.1.0",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+            "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+            "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -2184,6 +2216,18 @@
                 "sparse-bitfield": "^3.0.3"
             }
         },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "0.2.12",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+            "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.4.3",
+                "@emnapi/runtime": "^1.4.3",
+                "@tybys/wasm-util": "^0.10.0"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3099,11 +3143,273 @@
                 "@sinonjs/commons": "^3.0.0"
             }
         },
+        "node_modules/@snazzah/davey": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@snazzah/davey/-/davey-0.1.6.tgz",
+            "integrity": "sha512-wKJDQ7iobl3rvuQDXLC2yZdpuVxPvMnbyjyPpkcETqPfqNVrdyX9zSdV74dnkpx7aLpINEmKh8ZEIlCIJA2h1w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/Snazzah"
+            },
+            "optionalDependencies": {
+                "@snazzah/davey-android-arm-eabi": "0.1.6",
+                "@snazzah/davey-android-arm64": "0.1.6",
+                "@snazzah/davey-darwin-arm64": "0.1.6",
+                "@snazzah/davey-darwin-x64": "0.1.6",
+                "@snazzah/davey-freebsd-x64": "0.1.6",
+                "@snazzah/davey-linux-arm-gnueabihf": "0.1.6",
+                "@snazzah/davey-linux-arm64-gnu": "0.1.6",
+                "@snazzah/davey-linux-arm64-musl": "0.1.6",
+                "@snazzah/davey-linux-x64-gnu": "0.1.6",
+                "@snazzah/davey-linux-x64-musl": "0.1.6",
+                "@snazzah/davey-wasm32-wasi": "0.1.6",
+                "@snazzah/davey-win32-arm64-msvc": "0.1.6",
+                "@snazzah/davey-win32-ia32-msvc": "0.1.6",
+                "@snazzah/davey-win32-x64-msvc": "0.1.6"
+            }
+        },
+        "node_modules/@snazzah/davey-android-arm-eabi": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@snazzah/davey-android-arm-eabi/-/davey-android-arm-eabi-0.1.6.tgz",
+            "integrity": "sha512-6Fso+kxvvIcmUdTgU4etHjvEZUwGwvIk+SUYxKTRZKz/S62pZvcFeZfbofpQC5ZIlt/rdp7l+4IM62J7PUduxQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@snazzah/davey-android-arm64": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@snazzah/davey-android-arm64/-/davey-android-arm64-0.1.6.tgz",
+            "integrity": "sha512-5ZGLumjewJAmGAcHqSHb2+KZSSufdNY++/GouzqdQXfhs2bSNBPuHpNn94u6//5UK0o73udJ6B1H/uLOLfEBLQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@snazzah/davey-darwin-arm64": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@snazzah/davey-darwin-arm64/-/davey-darwin-arm64-0.1.6.tgz",
+            "integrity": "sha512-0k6gOm29bcznz4ND1gfJVKeCxfyFw/EtfhPQvQ2PPJToSIaSvVqfYIlj/v9ogWW/lzuPI4EbLP0b6hnZkKidbQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@snazzah/davey-darwin-x64": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@snazzah/davey-darwin-x64/-/davey-darwin-x64-0.1.6.tgz",
+            "integrity": "sha512-y9UuymB5JTi9LSwjsCZDf/mjI6nAum1+uYX2h4xdO+VUxXQSAR4B2mr3lCI7l9KwYqW7JVDN5wETithAkXcTYA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@snazzah/davey-freebsd-x64": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@snazzah/davey-freebsd-x64/-/davey-freebsd-x64-0.1.6.tgz",
+            "integrity": "sha512-G0XzHi+pZqTZ5Zr7Z66J6oGOG07+Obw7f0CwD9nAJcSFlKnd8wYzTjL+krHfQxmLHnuA5w/9df+M9oDJDcGcJw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@snazzah/davey-linux-arm-gnueabihf": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-arm-gnueabihf/-/davey-linux-arm-gnueabihf-0.1.6.tgz",
+            "integrity": "sha512-RaxTzO8iJfDvj4a8OcXRwcP+2WfaCcno28ZWFMTI0pHEviG3MfLH5COAIvtMQvg0XfC+HgFC4YA1d29S8Dhvbg==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@snazzah/davey-linux-arm64-gnu": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-arm64-gnu/-/davey-linux-arm64-gnu-0.1.6.tgz",
+            "integrity": "sha512-2BIJSWs4rHq4U9A7B6WtF1LzwYJrbFUz5SQVmwqwQXKJ8cm81iizqclDGWr3zFGiVPTXLZ/+G3wnQNDB54oABQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@snazzah/davey-linux-arm64-musl": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-arm64-musl/-/davey-linux-arm64-musl-0.1.6.tgz",
+            "integrity": "sha512-N1egO+HT8cvSdIGCzJNRVH3ZhxCIYKVYxEkfzVZaBx26snN8NF737YTVRldl84w//3tdgohyl27yrn+dMkWS2Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@snazzah/davey-linux-x64-gnu": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-x64-gnu/-/davey-linux-x64-gnu-0.1.6.tgz",
+            "integrity": "sha512-RAC96Y//HHoMP+1MUf4rOkBq5Nx6GCiOGeGsNXt7r02lbIthoFEPYFQdbfc9jYA79k67gpzmCa0N5ws7ZLVU5A==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@snazzah/davey-linux-x64-musl": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-x64-musl/-/davey-linux-x64-musl-0.1.6.tgz",
+            "integrity": "sha512-nBvxJTKlQFP9UsQ7ah78L+rGdcwLWKDR8z/knut/M+UZLe37vaponJAbY3F5ZqGAcfqJbwUi/CXR77t9E+TDmw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@snazzah/davey-wasm32-wasi": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@snazzah/davey-wasm32-wasi/-/davey-wasm32-wasi-0.1.6.tgz",
+            "integrity": "sha512-hvpZH6a4mYZiXv6vdZaFwjPProgFtb3k4BoMvEEJZDXsEPuIDgp+d2BX5Q9nVazdnJa/6JR/XCuObzugPWp0Ew==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^0.2.11"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@snazzah/davey-win32-arm64-msvc": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@snazzah/davey-win32-arm64-msvc/-/davey-win32-arm64-msvc-0.1.6.tgz",
+            "integrity": "sha512-iuxYXXa0Z8eAEZotAlMYUc5DCy3VonRXQMm8/w2EvM/ZzGBI7SMap0GhPf6HjArEW32ETarTLh1s/Yi/jhFPDQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@snazzah/davey-win32-ia32-msvc": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@snazzah/davey-win32-ia32-msvc/-/davey-win32-ia32-msvc-0.1.6.tgz",
+            "integrity": "sha512-QEubcCIBR+ZZoQzRzJuOuKcH2IaF2pFXU+t48ITHG1o2WL4NAnvc3IpfVQGhbkr+DlydZ6fKNMMEemd1pRZzRA==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@snazzah/davey-win32-x64-msvc": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@snazzah/davey-win32-x64-msvc/-/davey-win32-x64-msvc-0.1.6.tgz",
+            "integrity": "sha512-8tR3o+amQOHJL8QzSwuSCCave+jm3SC1m1OKSh9Coy4wN/XoJN0XQUxqzA7ineSClAMW3yIO0ShFmMlMIXsC0A==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
         "node_modules/@tokenizer/token": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
             "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
             "license": "MIT"
+        },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
+            "integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "@hapi/hapi": "^21.3.2",
         "@sentry/node": "^10.8.0",
         "@sentry/profiling-node": "^10.8.0",
+        "@snazzah/davey": "^0.1.6",
         "@types/jimp": "^0.2.1",
         "@types/node-cron": "^3.0.11",
         "axios": "^1.11.0",


### PR DESCRIPTION
## Summary
- Add missing @snazzah/davey dependency for Discord DAVE protocol voice connections
- Fixes /join command hanging with "Alia is thinking..." message
- Resolves voice service detection issues in /speak command

## Root Cause
The voice connection was failing due to missing DAVE protocol support. Discord.js v14 requires the @snazzah/davey package for proper voice connection handling.

## Test Plan
- [ ] Verify /join command completes successfully without hanging
- [ ] Confirm bot joins voice channel properly
- [ ] Test /speak command can detect bot's voice connection status
- [ ] Validate voice connection stability

## Technical Details
- Package: @snazzah/davey v0.1.6
- Protocol: Discord DAVE (Data And Voice Engine)
- Dependency type: Production (required for voice features)