### PR TITLE
fix: remove tone feature from /speak command (fixes #201)

### DIFF
--- a/src/commands/speak.test.ts
+++ b/src/commands/speak.test.ts
@@ -155,40 +155,7 @@ describe('speak command', () => {
             ]);
         });
 
-        it('should return all tones when tone query is empty', async () => {
-            mockAutocompleteInteraction.options.getFocused.mockReturnValue({
-                name: 'tone',
-                value: '',
-            });
-
-            await speakCommand.autocomplete(mockAutocompleteInteraction);
-
-            expect(mockAutocompleteInteraction.respond).toHaveBeenCalledWith([
-                { name: 'Neutral (Default)', value: 'neutral' },
-                { name: 'Happy/Excited', value: 'happy' },
-                { name: 'Sad/Melancholy', value: 'sad' },
-                { name: 'Angry/Intense', value: 'angry' },
-                { name: 'Calm/Soothing', value: 'calm' },
-                { name: 'Mysterious/Dark', value: 'mysterious' },
-                { name: 'Dramatic/Epic', value: 'dramatic' },
-                { name: 'Sarcastic/Witty', value: 'sarcastic' },
-            ]);
-        });
-
-        it('should filter tones by keywords', async () => {
-            mockAutocompleteInteraction.options.getFocused.mockReturnValue({
-                name: 'tone',
-                value: 'excited',
-            });
-
-            await speakCommand.autocomplete(mockAutocompleteInteraction);
-
-            expect(mockAutocompleteInteraction.respond).toHaveBeenCalledWith([
-                { name: 'Happy/Excited', value: 'happy' },
-            ]);
-        });
-
-        it('should handle non-voice and non-tone options', async () => {
+        it('should handle non-voice options', async () => {
             mockAutocompleteInteraction.options.getFocused.mockReturnValue({
                 name: 'text',
                 value: 'hello',
@@ -230,7 +197,6 @@ describe('speak command', () => {
         mockInteraction.options.getString.mockImplementation((option: string) => {
             if (option === 'text') {return 'x'.repeat(5000);} // Too long
             if (option === 'voice') {return 'alloy';}
-            if (option === 'tone') {return 'neutral';}
             return null;
         });
         mockInteraction.options.getBoolean.mockReturnValue(false);
@@ -247,7 +213,6 @@ describe('speak command', () => {
         mockInteraction.options.getString.mockImplementation((option: string) => {
             if (option === 'text') {return 'Hello world';}
             if (option === 'voice') {return 'invalid-voice';}
-            if (option === 'tone') {return 'neutral';}
             return null;
         });
         mockInteraction.options.getBoolean.mockReturnValue(false);
@@ -260,29 +225,10 @@ describe('speak command', () => {
         });
     });
 
-    it('should handle invalid tone option', async () => {
-        mockInteraction.options.getString.mockImplementation((option: string) => {
-            if (option === 'text') {return 'Hello world';}
-            if (option === 'voice') {return 'alloy';}
-            if (option === 'tone') {return 'invalid-tone';}
-            return null;
-        });
-        mockInteraction.options.getBoolean.mockReturnValue(false);
-
-        await speakCommand.execute(mockInteraction, mockContext);
-
-        expect(mockInteraction.reply).toHaveBeenCalledWith({
-            content: '❌ Invalid tone option. Valid tones are: ' +
-                'neutral, happy, sad, angry, calm, mysterious, dramatic, sarcastic',
-            ephemeral: true,
-        });
-    });
-
     it('should handle empty text', async () => {
         mockInteraction.options.getString.mockImplementation((option: string) => {
             if (option === 'text') {return '';}
             if (option === 'voice') {return 'alloy';}
-            if (option === 'tone') {return 'neutral';}
             return null;
         });
         mockInteraction.options.getBoolean.mockReturnValue(false);

--- a/src/commands/speak.ts
+++ b/src/commands/speak.ts
@@ -12,8 +12,6 @@ const VOICE_OPTIONS = [
     { name: 'Shimmer (Soft Female)', value: 'shimmer', keywords: ['soft', 'female', 'gentle', 'quiet'] },
 ];
 
-
-
 export default {
     data: new SlashCommandBuilder()
         .setName('speak')
@@ -88,7 +86,6 @@ export default {
                 });
                 return;
             }
-
 
             // Validate text length
             if (text.length > TTS_CONFIG.MAX_TEXT_LENGTH) {

--- a/src/commands/speak.ts
+++ b/src/commands/speak.ts
@@ -12,88 +12,7 @@ const VOICE_OPTIONS = [
     { name: 'Shimmer (Soft Female)', value: 'shimmer', keywords: ['soft', 'female', 'gentle', 'quiet'] },
 ];
 
-const TONE_OPTIONS = [
-    { name: 'Neutral (Default)', value: 'neutral', keywords: ['normal', 'default', 'regular'] },
-    { name: 'Happy/Excited', value: 'happy', keywords: ['excited', 'joyful', 'cheerful', 'upbeat'] },
-    { name: 'Sad/Melancholy', value: 'sad', keywords: ['melancholy', 'somber', 'depressed', 'down'] },
-    { name: 'Angry/Intense', value: 'angry', keywords: ['mad', 'furious', 'intense', 'rage'] },
-    { name: 'Calm/Soothing', value: 'calm', keywords: ['peaceful', 'relaxed', 'zen', 'tranquil'] },
-    { name: 'Mysterious/Dark', value: 'mysterious', keywords: ['dark', 'eerie', 'ominous', 'spooky'] },
-    { name: 'Dramatic/Epic', value: 'dramatic', keywords: ['epic', 'theatrical', 'grand', 'powerful'] },
-    { name: 'Sarcastic/Witty', value: 'sarcastic', keywords: ['witty', 'ironic', 'dry', 'clever'] },
-];
 
-/**
- * Apply emotional tone to text by adding contextual modifiers
- * Since OpenAI TTS doesn't have tone parameters, we modify the input text
- * to naturally influence the speech patterns and delivery
- */
-function applyEmotionalTone(text: string, tone: string): string {
-    if (tone === 'neutral') {
-        return text;
-    }
-
-    const toneModifiers: Record<string, {
-        prefix: string;
-        suffix: string;
-        textModifier?: (s: string) => string; // eslint-disable-line no-unused-vars
-    }> = {
-        happy: {
-            prefix: '[Speaking with joy and enthusiasm] ',
-            suffix: ' [End with upbeat energy]',
-            textModifier: text => {
-                // Add exclamation if no punctuation, or convert existing punctuation to exclamation
-                if (text.match(/[.!?]+$/)) {
-                    return text.replace(/[.!?]+$/g, match => match.includes('!') ? match : '!');
-                } else {
-                    return text + '!';
-                }
-            },
-        },
-        sad: {
-            prefix: '[Speaking with melancholy and somber tone] ',
-            suffix: ' [End with quiet reflection]',
-            textModifier: text => text.replace(/!/g, '.').toLowerCase(),
-        },
-        angry: {
-            prefix: '[Speaking with intensity and force] ',
-            suffix: ' [End with strong emphasis]',
-            textModifier: text => text.toUpperCase().replace(/[.?]/g, '!'),
-        },
-        calm: {
-            prefix: '[Speaking with peaceful, soothing tone] ',
-            suffix: ' [End with gentle calmness]',
-            textModifier: text => text.replace(/!/g, '.').replace(/[A-Z]/g, match => match.toLowerCase()),
-        },
-        mysterious: {
-            prefix: '[Speaking with mysterious, dark undertones] ',
-            suffix: ' [End with ominous pause]',
-            textModifier: text => text.replace(/!/g, '...'),
-        },
-        dramatic: {
-            prefix: '[Speaking with grand, theatrical presence] ',
-            suffix: ' [End with dramatic flourish]',
-            textModifier: text => text.replace(/\b(\w)/g, match => match.toUpperCase()),
-        },
-        sarcastic: {
-            prefix: '[Speaking with dry wit and subtle irony] ',
-            suffix: ' [End with knowing pause]',
-            textModifier: text => `"${text}"`, // Add quotes to emphasize sarcasm
-        },
-    };
-
-    const modifier = toneModifiers[tone];
-    if (!modifier) {
-        return text;
-    }
-
-    let processedText = text;
-    if (modifier.textModifier) {
-        processedText = modifier.textModifier(text);
-    }
-
-    return `${modifier.prefix}${processedText}${modifier.suffix}`;
-}
 
 export default {
     data: new SlashCommandBuilder()
@@ -108,12 +27,6 @@ export default {
             option
                 .setName('voice')
                 .setDescription('Voice to use for TTS (type to search)')
-                .setRequired(false)
-                .setAutocomplete(true))
-        .addStringOption(option =>
-            option
-                .setName('tone')
-                .setDescription('Emotional tone for the speech (type to search)')
                 .setRequired(false)
                 .setAutocomplete(true))
         .addBooleanOption(option =>
@@ -143,23 +56,6 @@ export default {
             );
         }
 
-        if (focusedOption.name === 'tone') {
-            const query = focusedOption.value.toLowerCase();
-
-            let filtered = TONE_OPTIONS.filter(tone =>
-                // Match by name or keywords
-                tone.name.toLowerCase().includes(query) ||
-                tone.value.toLowerCase().includes(query) ||
-                tone.keywords.some(keyword => keyword.includes(query)),
-            );
-
-            // Limit to 25 options (Discord's limit)
-            filtered = filtered.slice(0, 25);
-
-            await interaction.respond(
-                filtered.map(tone => ({ name: tone.name, value: tone.value })),
-            );
-        }
     },
 
     async execute(interaction: any, context: Context) {
@@ -181,7 +77,6 @@ export default {
 
             const text = interaction.options.getString('text');
             const voice = interaction.options.getString('voice') || 'alloy';
-            const tone = interaction.options.getString('tone') || 'neutral';
             const joinUser = interaction.options.getBoolean('join_user') || false;
 
             // Validate voice option
@@ -194,15 +89,6 @@ export default {
                 return;
             }
 
-            // Validate tone option
-            const validTones = TONE_OPTIONS.map(t => t.value);
-            if (!validTones.includes(tone)) {
-                await interaction.reply({
-                    content: `❌ Invalid tone option. Valid tones are: ${validTones.join(', ')}`,
-                    ephemeral: true,
-                });
-                return;
-            }
 
             // Validate text length
             if (text.length > TTS_CONFIG.MAX_TEXT_LENGTH) {
@@ -272,26 +158,23 @@ export default {
                 return;
             }
 
-            // Process text with emotional tone
-            const processedText = applyEmotionalTone(text, tone);
+            // Use text as-is without any processing
+            const processedText = text;
 
             log.info('TTS command initiated by owner', {
                 userId: interaction.user.id,
                 username: interaction.user.username,
                 guildId: guild.id,
                 textLength: text.length,
-                processedTextLength: processedText.length,
                 voice: voice,
-                tone: tone,
             });
 
             try {
                 // Generate and play TTS
                 await voiceService.speakText(processedText, guild.id, voice as any);
 
-                const toneDisplay = tone === 'neutral' ? '' : ` with ${tone} tone`;
                 await interaction.followUp({
-                    content: `✅ Successfully spoke text using ${voice} voice${toneDisplay}.`,
+                    content: `✅ Successfully spoke text using ${voice} voice.`,
                     ephemeral: true,
                 });
 
@@ -300,7 +183,6 @@ export default {
                     guildId: guild.id,
                     textLength: text.length,
                     voice: voice,
-                    tone: tone,
                 });
 
             } catch (error) {
@@ -314,7 +196,6 @@ export default {
                     guildId: guild.id,
                     textLength: text.length,
                     voice: voice,
-                    tone: tone,
                     error: error,
                 });
             }


### PR DESCRIPTION
## Summary
- Removes the problematic `tone` feature from the `/speak` command that was reading wrapper text literally
- Simplifies the TTS functionality to use text as-is without emotional tone processing
- Improves user experience by eliminating unwanted prefix/suffix text being spoken

## Changes Made
- 🗑️ **Removed `TONE_OPTIONS` array** - All 8 emotional tone options
- 🗑️ **Removed `applyEmotionalTone()` function** - Function that added problematic wrapper text
- 🗑️ **Removed tone option from SlashCommandBuilder** - No longer available in Discord UI
- 🗑️ **Removed tone autocomplete handling** - Cleaned up autocomplete logic
- 🗑️ **Removed tone validation and logging** - Simplified parameter handling
- ✅ **Simplified text processing** - Now uses text as-is without modifications

## Issue Description
The `tone` feature added wrapper text like `"[Speaking with joy and enthusiasm] Your message here [End with upbeat energy]"` which the OpenAI TTS API read literally instead of applying as emotional context. This created a poor user experience where users heard the wrapper instructions instead of just their message with emotional inflection.

## Test Plan
- [x] Code compiles successfully (`npm run build`)
- [ ] `/speak` command works with only `text`, `voice`, and `join_user` options
- [ ] No tone option appears in Discord autocomplete
- [ ] TTS speaks only the user's text without wrapper phrases
- [ ] Command deployment to production guilds removes tone option

## Breaking Changes
⚠️ **This is a breaking change** - the `tone` parameter is completely removed from the `/speak` command.

**Required Follow-up Actions:**
1. Deploy updated commands to production guilds to remove tone option from Discord UI
2. Update any documentation that references the tone feature

## Related
Fixes #201 - Remove tone feature from /speak command - API reads wrapping text literally

🤖 Generated with [Claude Code](https://claude.ai/code)