### PR TITLE
feat: exclude development commands from production deployment

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -92,6 +92,12 @@ async function loadFiles<T>(directory: string, extension: string, handleFile: (m
 }
 
 function handleCommandFile(command: BotCommand, fullPath: string) {
+    // Filter out development-only commands in production
+    if (command.developmentOnly && process.env.NODE_ENV === 'production') {
+        log.info(`Skipping development-only command: ${command.data?.name || 'unknown'}`);
+        return;
+    }
+    
     if (command.data) {
         client.commands.set(command.data.name, command);
     } else {

--- a/index.ts
+++ b/index.ts
@@ -97,7 +97,7 @@ function handleCommandFile(command: BotCommand, fullPath: string) {
         log.info(`Skipping development-only command: ${command.data?.name || 'unknown'}`);
         return;
     }
-    
+
     if (command.data) {
         client.commands.set(command.data.name, command);
     } else {

--- a/scripts/deploy-commands.js
+++ b/scripts/deploy-commands.js
@@ -30,6 +30,12 @@ for (const file of commandFiles) {
         const command = require(filePath);
         
         if (command.default && command.default.data) {
+            // Skip development-only commands in production
+            if (command.default.developmentOnly && process.env.NODE_ENV === 'production') {
+                console.log(`⏭️ Skipping development-only command: ${command.default.data.name}`);
+                continue;
+            }
+            
             // Convert SlashCommandBuilder to JSON
             const commandData = command.default.data.toJSON ? 
                 command.default.data.toJSON() : 

--- a/src/commands/reload.ts
+++ b/src/commands/reload.ts
@@ -21,6 +21,7 @@ async function reloadCommand(client: any, commandName: any, log: any) {
 }
 
 export default {
+    developmentOnly: true, // This command should only be available in development
     data: new SlashCommandBuilder()
         .setName('reload')
         .setDescription('Reloads a command.')

--- a/src/commands/sentry-test.ts
+++ b/src/commands/sentry-test.ts
@@ -3,6 +3,8 @@ import { Context } from '../utils/types';
 import { Sentry } from '../lib/sentry';
 import { checkOwnerPermission } from '../utils/permissions';
 
+export const developmentOnly = true; // This command should only be available in development
+
 export const data = new SlashCommandBuilder()
     .setName('sentry-test')
     .setDescription('Test Sentry connectivity and logging (Owner only)');

--- a/src/types/discord.ts
+++ b/src/types/discord.ts
@@ -12,6 +12,7 @@ import { Context } from './index';
 // Command interface
 export interface BotCommand {
     data: SlashCommandBuilder;
+    developmentOnly?: boolean; // Flag to mark commands that should only be available in development
     execute(interaction: CommandInteraction, context: Context): Promise<void>;
     autocomplete?(interaction: AutocompleteInteraction, context: Context): Promise<void>;
 }


### PR DESCRIPTION
## Summary
- Implements environment-based filtering to completely exclude development commands from production deployments
- Adds `developmentOnly` flag to commands that should only be available in development
- Updates bot initialization and deployment scripts to respect the flag when `NODE_ENV=production`

## Changes Made
- ✅ Added `developmentOnly: true` flag to `/reload` and `/sentry-test` commands
- ✅ Modified `handleCommandFile()` in `index.ts` to skip dev commands in production
- ✅ Updated `BotCommand` interface to include optional `developmentOnly` property
- ✅ Updated `deploy-commands.js` script to filter dev commands during deployment
- ✅ Verified commands are properly filtered in compiled output

## Security Benefits
- **Complete exclusion**: Dev commands are not registered with Discord in production
- **Clean separation**: Clear distinction between dev and prod command sets
- **No permission bypass**: Commands cannot be accessed even with elevated permissions
- **Reduced attack surface**: Sensitive commands like `/reload` are completely unavailable

## Testing
- ✅ Build succeeds with proper TypeScript compilation
- ✅ Commands are correctly flagged in compiled JavaScript
- ✅ No breaking changes to existing command structure
- ✅ Development environment still has full command access

Closes #203