### PR TITLE
feat: improve CI workflow by making Claude review depend on basic checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,40 @@ jobs:
             echo "✅ Coverage $COVERAGE% meets minimum threshold of 40%"
           fi
 
+  claude-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    needs: [Lint, Test, Coverage]
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+            
+            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+
+            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+          
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,17 +1,16 @@
-name: Claude Code Review
+# This workflow has been consolidated into ci.yml
+# The claude-review job now runs after lint, test, and coverage pass
+# This prevents unnecessary Claude reviews on PRs with failing basic checks
+
+name: Claude Code Review (DEPRECATED)
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  # Disabled - functionality moved to ci.yml
+  workflow_dispatch:
+    # Manual trigger only for testing
 
 jobs:
-  claude-review:
+  claude-review-deprecated:
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## Summary

Improves the CI workflow by preventing Claude Code reviews from running until lint, tests, and coverage checks pass. This addresses the issue where Claude reviews were wasting CI resources on PRs that failed basic code quality checks.

### Changes Made

- **Consolidated Claude review into main CI workflow**: Moved the `claude-review` job from a separate workflow file into `ci.yml`
- **Added job dependencies**: Claude review now uses `needs: [Lint, Test, Coverage]` to wait for basic checks
- **Added conditional execution**: Only runs on pull requests (`if: github.event_name == 'pull_request'`)
- **Deprecated old workflow**: Marked `claude-code-review.yml` as deprecated and disabled auto-triggering

### Benefits

- **Saves CI resources**: Claude reviews only run after confirming the code meets basic quality standards
- **Faster feedback**: Developers get lint/test results immediately without waiting for Claude review
- **Better workflow**: Prevents reviewing code that will need fixes for basic issues
- **Cleaner PR status**: Failed lint/tests will block Claude review, making PR status cleaner

### Test Plan

- [x] Verify workflow syntax is valid
- [x] Commit includes both workflow files with proper changes
- [ ] Test on a PR to ensure Claude review waits for other checks
- [ ] Confirm deprecated workflow no longer auto-triggers

Addresses the user request: "Create a new branch and PR to make claude code CI check not happen until the lint and tests pass"

🤖 Generated with [Claude Code](https://claude.ai/code)