### PR TITLE
feat: make horoscope and fortune embeds public by default

### DIFF
--- a/src/commands/fortune.test.ts
+++ b/src/commands/fortune.test.ts
@@ -38,14 +38,14 @@ describe('fortune command', () => {
         expect(fortuneCommand.data.description).toBe('Receive a fortune cookie message');
     });
 
-    it('should send private fortune by default', async () => {
+    it('should send public fortune by default', async () => {
         mockInteraction.options.getBoolean.mockReturnValue(false);
 
         await fortuneCommand.execute(mockInteraction, mockContext);
 
         expect(mockInteraction.reply).toHaveBeenCalledWith({
             content: expect.stringContaining('🥠 **Your Fortune Cookie** 🥠'),
-            ephemeral: true,
+            ephemeral: false,
         });
 
         // Verify the fortune message structure
@@ -55,14 +55,14 @@ describe('fortune command', () => {
         expect(replyCall.content).toContain('Fortune Level:');
     });
 
-    it('should send public fortune when requested', async () => {
+    it('should send private fortune when requested', async () => {
         mockInteraction.options.getBoolean.mockReturnValue(true);
 
         await fortuneCommand.execute(mockInteraction, mockContext);
 
         expect(mockInteraction.reply).toHaveBeenCalledWith({
             content: expect.stringContaining('🥠 **Your Fortune Cookie** 🥠'),
-            ephemeral: false,
+            ephemeral: true,
         });
     });
 
@@ -121,7 +121,7 @@ describe('fortune command', () => {
                 userId: 'test-user-id',
                 username: 'testuser',
                 guildId: 'test-guild-id',
-                isPublic: true,
+                isPrivate: true,
                 fortune: expect.any(String),
             }),
         );
@@ -156,7 +156,7 @@ describe('fortune command', () => {
 
         expect(mockInteraction.reply).toHaveBeenCalledWith({
             content: expect.stringContaining('🥠 **Your Fortune Cookie** 🥠'),
-            ephemeral: true,
+            ephemeral: false,
         });
 
         expect(mockContext.log.info).toHaveBeenCalledWith(

--- a/src/commands/fortune.ts
+++ b/src/commands/fortune.ts
@@ -73,13 +73,13 @@ export default {
         .setDescription('Receive a fortune cookie message')
         .addBooleanOption(option =>
             option
-                .setName('public')
-                .setDescription('Share your fortune with the channel (default: private)')
+                .setName('private')
+                .setDescription('Keep your fortune private (default: public)')
                 .setRequired(false)),
 
     async execute(interaction: any, context: Context) {
         const { log } = context;
-        const isPublic = interaction.options.getBoolean('public') || false;
+        const isPrivate = interaction.options.getBoolean('private') || false;
 
         try {
             // Select a random fortune
@@ -96,14 +96,14 @@ export default {
 
             await interaction.reply({
                 content: fortuneMessage,
-                ephemeral: !isPublic,
+                ephemeral: isPrivate,
             });
 
             log.info('Fortune command executed', {
                 userId: interaction.user.id,
                 username: interaction.user.username,
                 guildId: interaction.guild?.id,
-                isPublic: isPublic,
+                isPrivate: isPrivate,
                 fortune: fortune.substring(0, 50) + '...', // Log partial fortune
             });
 

--- a/src/commands/horoscope.test.ts
+++ b/src/commands/horoscope.test.ts
@@ -152,8 +152,8 @@ describe('Horoscope Command', () => {
                 expect(choices.some((c: any) => c.value === 'today')).toBe(true);
             }
 
-            const publicOption = options.find((opt: any) => opt.name === 'public');
-            expect(publicOption).toBeDefined();
+            const privateOption = options.find((opt: any) => opt.name === 'private');
+            expect(privateOption).toBeDefined();
         });
     });
 
@@ -215,7 +215,7 @@ describe('Horoscope Command', () => {
 
             await horoscopeCommand.execute(mockInteraction, mockContext);
 
-            expect(mockInteraction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+            expect(mockInteraction.deferReply).toHaveBeenCalledWith({ ephemeral: false });
             expect(mockInteraction.editReply).toHaveBeenCalledWith({
                 content: expect.stringContaining('❌ "invalidSign" is not a valid zodiac sign'),
             });
@@ -453,22 +453,22 @@ describe('Horoscope Command', () => {
     });
 
     describe('Public vs Private Display', () => {
-        test('should default to private display', async () => {
+        test('should default to public display', async () => {
             mockInteraction.options.getString.mockReturnValue('aries');
             mockInteraction.options.getBoolean.mockReturnValue(false);
 
             await horoscopeCommand.execute(mockInteraction, mockContext);
 
-            expect(mockInteraction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+            expect(mockInteraction.deferReply).toHaveBeenCalledWith({ ephemeral: false });
         });
 
-        test('should support public display when requested', async () => {
+        test('should support private display when requested', async () => {
             mockInteraction.options.getString.mockReturnValue('taurus');
             mockInteraction.options.getBoolean.mockReturnValue(true);
 
             await horoscopeCommand.execute(mockInteraction, mockContext);
 
-            expect(mockInteraction.deferReply).toHaveBeenCalledWith({ ephemeral: false });
+            expect(mockInteraction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
         });
     });
 
@@ -553,7 +553,7 @@ describe('Horoscope Command', () => {
                 sign: 'aquarius',
                 type: 'weekly',
                 period: 'this-week',
-                isPublic: true,
+                isPrivate: true,
             });
         });
     });

--- a/src/commands/horoscope.ts
+++ b/src/commands/horoscope.ts
@@ -40,8 +40,8 @@ export default {
                 ))
         .addBooleanOption(option =>
             option
-                .setName('public')
-                .setDescription('Share your horoscope with the channel (default: private)')
+                .setName('private')
+                .setDescription('Keep your horoscope private (default: public)')
                 .setRequired(false)),
 
     async autocomplete(interaction: any, context: Context) {
@@ -65,13 +65,13 @@ export default {
 
         try {
             await interaction.deferReply({
-                ephemeral: !interaction.options.getBoolean('public'),
+                ephemeral: interaction.options.getBoolean('private') || false,
             });
 
             const userInput = interaction.options.getString('sign');
             const type = interaction.options.getString('type') || 'daily';
             const period = interaction.options.getString('period') || 'today';
-            const isPublic = interaction.options.getBoolean('public') || false;
+            const isPrivate = interaction.options.getBoolean('private') || false;
 
             // Validate zodiac sign input
             const normalizedSign = userInput!.toLowerCase();
@@ -116,7 +116,7 @@ export default {
                 sign: zodiacSign,
                 type,
                 period,
-                isPublic,
+                isPrivate,
             });
 
         } catch (error) {


### PR DESCRIPTION
## Summary
Changes horoscope and fortune commands to display their embeds publicly in channels by default, instead of as private ephemeral messages.

## Changes Made
- **Semantic improvement**: Changed 'public' boolean option to 'private' boolean option for clearer user intent
- **Default behavior**: Commands now default to `ephemeral: false` (public/visible to everyone)
- **User control**: Users can still opt for private responses using the new 'private' option
- **Test updates**: Updated all test expectations to match new public-first behavior
- **Backward compatibility**: Maintains functionality for users who want private responses

## Before vs After
**Before:**
- Commands defaulted to private (ephemeral: true)
- Users had to explicitly set `public: true` to share with channel
- Option was confusing: "public" parameter to control privacy

**After:**
- Commands default to public (ephemeral: false) - more social and engaging
- Users can set `private: true` to keep responses private
- Clearer semantics: "private" parameter when you want privacy

## Testing
- ✅ All fortune command tests pass (11/11)
- ✅ All horoscope command tests pass (21/21)  
- ✅ Full test suite passes (566/566 tests)
- ✅ Both commands tested in public and private modes
- ✅ Guild context and no-guild context scenarios covered

## Impact
- **User Experience**: More engaging as fun content is shared by default
- **Discord Culture**: Aligns with social nature of Discord servers
- **Discoverability**: Other users can see and discover these fun commands
- **Privacy**: Still respects users who want private readings

🤖 Generated with [Claude Code](https://claude.ai/code)