### PR TITLE
feat: stock tracking + Alia personality + assistant provider swap

### DIFF
--- a/src/responses/assistant.test.ts
+++ b/src/responses/assistant.test.ts
@@ -4,10 +4,19 @@ import { Context } from '../utils/types';
 // Mock the dependencies BEFORE importing the module that uses them
 jest.mock('../utils/assistant');
 jest.mock('../utils/discordHelpers');
+jest.mock('../utils/alia-context', () => ({
+    gatherAliaContext: jest.fn().mockResolvedValue({
+        speakerDescriptions: [],
+        mentionedUsers: [],
+        relevantMemories: [],
+        history: [],
+    }),
+}));
 
 import assistantResponse from './assistant';
 import generateResponse from '../utils/assistant';
 import { safelySendToChannel } from '../utils/discordHelpers';
+import { _resetForTests as resetHistory } from '../utils/conversation-history';
 
 // Mock openai SDK (used by OpenRouter client) to prevent instantiation errors
 jest.mock('openai', () => ({
@@ -31,6 +40,7 @@ describe('Assistant Response System', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        resetHistory();
 
         mockChannel = {
             send: jest.fn().mockResolvedValue({ id: 'message-123' }),
@@ -175,8 +185,10 @@ describe('Assistant Response System', () => {
                 {
                     userId: 'test-user-id',
                     username: 'testuser',
+                    displayName: 'testuser',
                     channelId: 'test-channel-id',
                 },
+                expect.any(Object),
             );
             expect(mockSafelySendToChannel).toHaveBeenCalledWith(
                 mockChannel,
@@ -264,6 +276,7 @@ describe('Assistant Response System', () => {
                 'what is DNA?',
                 mockContext,
                 expect.any(Object),
+                expect.any(Object),
             );
         });
 
@@ -275,6 +288,7 @@ describe('Assistant Response System', () => {
             expect(mockGenerateResponse).toHaveBeenCalledWith(
                 'what is RNA?',
                 mockContext,
+                expect.any(Object),
                 expect.any(Object),
             );
         });
@@ -288,6 +302,7 @@ describe('Assistant Response System', () => {
                 'what is ATP?',
                 mockContext,
                 expect.any(Object),
+                expect.any(Object),
             );
         });
 
@@ -300,6 +315,7 @@ describe('Assistant Response System', () => {
             expect(mockGenerateResponse).toHaveBeenCalledWith(
                 '@Alia what is mitochondria?',
                 mockContext,
+                expect.any(Object),
                 expect.any(Object),
             );
         });

--- a/src/responses/assistant.ts
+++ b/src/responses/assistant.ts
@@ -2,33 +2,42 @@ import { Message } from 'discord.js';
 import generateResponse from '../utils/assistant';
 import { Context } from '../utils/types';
 import { safelySendToChannel } from '../utils/discordHelpers';
+import { gatherAliaContext } from '../utils/alia-context';
+import { recordMessage } from '../utils/conversation-history';
 
 export default async (message: Message, context: Context): Promise<boolean> => {
     if (message.author.bot) {
         return false;
     }
 
-    // Only process messages that explicitly address the bot
+    // Only process messages that explicitly address the bot.
+    // ignoreEveryone prevents @here / @everyone from looking like a direct mention.
     const content = message.content.toLowerCase().trim();
-    const botMentioned = message.mentions.has(message.client.user!);
+    const botMentioned = message.client.user
+        ? message.mentions.has(message.client.user, {
+            ignoreEveryone: true,
+            ignoreRoles: true,
+            ignoreRepliedUser: true,
+        })
+        : false;
     const startsWithAlia = content.startsWith('alia,') || content.startsWith('alia ');
 
     if (!botMentioned && !startsWithAlia) {
         return false;
     }
 
-    // Remove the "Alia," prefix for processing
     let processableContent = message.content;
     if (startsWithAlia) {
         processableContent = message.content.replace(/^alia,?\s*/i, '').trim();
     }
 
-    // If after removing prefix, there's no meaningful content, skip
     if (!processableContent || processableContent.length < 3) {
         return false;
     }
 
     const startTime = Date.now();
+    const speakerName = (message.member?.displayName) || message.author.username;
+
     context.log.info('Assistant processing message', {
         userId: message.author.id,
         botMentioned,
@@ -37,11 +46,22 @@ export default async (message: Message, context: Context): Promise<boolean> => {
     });
 
     try {
-        const response = await generateResponse(processableContent, context, {
-            userId: message.author.id,
-            username: message.author.username,
-            channelId: message.channelId,
-        });
+        const extras = await gatherAliaContext(message, context);
+
+        // Record the incoming message in history BEFORE calling generateResponse
+        // so the model sees it as the latest user turn via the explicit user
+        // message, and sees prior context via history.
+        const response = await generateResponse(
+            processableContent,
+            context,
+            {
+                userId: message.author.id,
+                username: message.author.username,
+                displayName: speakerName,
+                channelId: message.channelId,
+            },
+            extras,
+        );
 
         if (response && message.channel && 'send' in message.channel) {
             const success = await safelySendToChannel(
@@ -53,6 +73,10 @@ export default async (message: Message, context: Context): Promise<boolean> => {
 
             const processingTime = Date.now() - startTime;
             if (success) {
+                // Only persist turns we actually delivered.
+                recordMessage(message.channelId, 'user', speakerName, processableContent);
+                recordMessage(message.channelId, 'assistant', 'Alia', response);
+
                 context.log.info('Assistant response sent', {
                     userId: message.author.id,
                     responseLength: response.length,
@@ -78,4 +102,4 @@ export default async (message: Message, context: Context): Promise<boolean> => {
         });
         return false;
     }
-}
+};

--- a/src/utils/alia-context.test.ts
+++ b/src/utils/alia-context.test.ts
@@ -1,0 +1,124 @@
+import { gatherAliaContext } from './alia-context';
+import { _resetForTests, recordMessage } from './conversation-history';
+
+describe('gatherAliaContext', () => {
+    beforeEach(() => {
+        _resetForTests();
+    });
+
+    function buildContext(overrides: Partial<any> = {}) {
+        return {
+            tables: {
+                UserDescriptions: {
+                    findAll: jest.fn().mockResolvedValue([]),
+                },
+                Memories: {
+                    findAll: jest.fn().mockResolvedValue([]),
+                },
+                ...overrides.tables,
+            },
+            log: { warn: jest.fn(), info: jest.fn(), debug: jest.fn(), error: jest.fn() },
+        } as any;
+    }
+
+    function buildMessage(overrides: any = {}) {
+        return {
+            guildId: 'g1',
+            channelId: 'c1',
+            content: 'hello world',
+            author: { id: 'u-speaker' },
+            client: { user: { id: 'bot' } },
+            mentions: {
+                users: overrides.mentionedUsers ?? new Map(),
+            },
+            ...overrides,
+        } as any;
+    }
+
+    it('fetches descriptions for the speaker', async () => {
+        const ctx = buildContext();
+        ctx.tables.UserDescriptions.findAll.mockResolvedValueOnce([
+            { description: 'a badass guitarist' },
+            { description: 'always late' },
+        ]);
+
+        const result = await gatherAliaContext(buildMessage(), ctx);
+
+        expect(result.speakerDescriptions).toEqual(['a badass guitarist', 'always late']);
+        expect(ctx.tables.UserDescriptions.findAll).toHaveBeenCalledWith({
+            where: { guild_id: 'g1', user_id: 'u-speaker' },
+            limit: 5,
+        });
+    });
+
+    it('fetches descriptions for mentioned users (excluding speaker and bot)', async () => {
+        const ctx = buildContext();
+        ctx.tables.UserDescriptions.findAll
+            .mockResolvedValueOnce([]) // speaker
+            .mockResolvedValueOnce([{ description: 'the one who pays' }]);
+
+        const mentionedUsers = new Map<string, any>();
+        mentionedUsers.set('u-speaker', { id: 'u-speaker', username: 'self' });
+        mentionedUsers.set('bot', { id: 'bot', username: 'Alia' });
+        mentionedUsers.set('u-other', { id: 'u-other', username: 'Derek' });
+
+        const msg = buildMessage({ mentionedUsers });
+        const result = await gatherAliaContext(msg, ctx);
+
+        expect(result.mentionedUsers).toEqual([
+            { displayName: 'Derek', descriptions: ['the one who pays'] },
+        ]);
+    });
+
+    it('matches memories whose key appears in the message', async () => {
+        const ctx = buildContext();
+        ctx.tables.Memories.findAll.mockResolvedValueOnce([
+            { key: 'dota', value: 'the game we all love to hate' },
+            { key: 'unrelated', value: 'nope' },
+            { key: 'world', value: 'big place' },
+        ]);
+
+        const msg = buildMessage({ content: 'hello world, are you playing dota tonight?' });
+        const result = await gatherAliaContext(msg, ctx);
+
+        const keys = result.relevantMemories.map(m => m.key);
+        expect(keys).toContain('dota');
+        expect(keys).toContain('world');
+        expect(keys).not.toContain('unrelated');
+    });
+
+    it('skips memory keys shorter than the minimum', async () => {
+        const ctx = buildContext();
+        ctx.tables.Memories.findAll.mockResolvedValueOnce([
+            { key: 'a', value: 'too short' },
+            { key: 'ok', value: 'also too short' },
+        ]);
+        const result = await gatherAliaContext(buildMessage({ content: 'a ok' }), ctx);
+        expect(result.relevantMemories).toHaveLength(0);
+    });
+
+    it('includes channel history', async () => {
+        recordMessage('c1', 'user', 'alice', 'earlier');
+        const ctx = buildContext();
+        const result = await gatherAliaContext(buildMessage(), ctx);
+        expect(result.history).toHaveLength(1);
+        expect(result.history[0].content).toBe('earlier');
+    });
+
+    it('returns empty context when not in a guild', async () => {
+        const ctx = buildContext();
+        const msg = buildMessage({ guildId: null });
+        const result = await gatherAliaContext(msg, ctx);
+        expect(result.speakerDescriptions).toEqual([]);
+        expect(result.mentionedUsers).toEqual([]);
+        expect(ctx.tables.UserDescriptions.findAll).not.toHaveBeenCalled();
+    });
+
+    it('swallows errors and returns safe defaults', async () => {
+        const ctx = buildContext();
+        ctx.tables.UserDescriptions.findAll.mockRejectedValueOnce(new Error('db down'));
+        const result = await gatherAliaContext(buildMessage(), ctx);
+        expect(result.speakerDescriptions).toEqual([]);
+        expect(ctx.log.warn).toHaveBeenCalled();
+    });
+});

--- a/src/utils/alia-context.ts
+++ b/src/utils/alia-context.ts
@@ -1,0 +1,94 @@
+import { Message } from 'discord.js';
+import { Context } from './types';
+import { getHistory, HistoryEntry } from './conversation-history';
+
+export interface MentionedUserContext {
+    displayName: string;
+    descriptions: string[];
+}
+
+export interface AliaExtraContext {
+    speakerDescriptions: string[];
+    mentionedUsers: MentionedUserContext[];
+    relevantMemories: { key: string; value: string }[];
+    history: HistoryEntry[];
+}
+
+const MAX_DESCRIPTIONS_PER_USER = 5;
+const MAX_RELEVANT_MEMORIES = 4;
+const MEMORY_FETCH_LIMIT = 500;
+const MIN_MEMORY_KEY_LENGTH = 3;
+
+async function fetchDescriptions(
+    tables: Context['tables'],
+    guildId: string,
+    userId: string,
+): Promise<string[]> {
+    const rows = await tables.UserDescriptions.findAll({
+        where: { guild_id: guildId, user_id: userId },
+        limit: MAX_DESCRIPTIONS_PER_USER,
+    });
+    return rows.map((r: any) => r.description);
+}
+
+async function findRelevantMemories(
+    tables: Context['tables'],
+    messageContent: string,
+): Promise<{ key: string; value: string }[]> {
+    const haystack = messageContent.toLowerCase();
+    const memories = await tables.Memories.findAll({ limit: MEMORY_FETCH_LIMIT });
+    const matches: { key: string; value: string }[] = [];
+    for (const mem of memories) {
+        const key = (mem as any).key as string;
+        if (!key || key.length < MIN_MEMORY_KEY_LENGTH) {continue;}
+        if (haystack.includes(key.toLowerCase())) {
+            matches.push({ key, value: (mem as any).value });
+            if (matches.length >= MAX_RELEVANT_MEMORIES) {break;}
+        }
+    }
+    return matches;
+}
+
+export async function gatherAliaContext(
+    message: Message,
+    context: Context,
+): Promise<AliaExtraContext> {
+    const { tables, log } = context;
+    const guildId = message.guildId;
+
+    const result: AliaExtraContext = {
+        speakerDescriptions: [],
+        mentionedUsers: [],
+        relevantMemories: [],
+        history: getHistory(message.channelId),
+    };
+
+    try {
+        if (guildId) {
+            result.speakerDescriptions = await fetchDescriptions(
+                tables, guildId, message.author.id,
+            );
+
+            const mentionedIds = new Set<string>();
+            message.mentions.users.forEach(u => {
+                if (u.id !== message.author.id && u.id !== message.client.user?.id) {
+                    mentionedIds.add(u.id);
+                }
+            });
+
+            for (const userId of mentionedIds) {
+                const descriptions = await fetchDescriptions(tables, guildId, userId);
+                if (descriptions.length === 0) {continue;}
+                const member = message.mentions.users.get(userId);
+                const displayName = member?.username ?? userId;
+                result.mentionedUsers.push({ displayName, descriptions });
+            }
+        }
+
+        result.relevantMemories = await findRelevantMemories(tables, message.content);
+    } catch (error) {
+        log.warn('Failed to gather Alia context', { error });
+    }
+
+    return result;
+}

--- a/src/utils/alia-mood.test.ts
+++ b/src/utils/alia-mood.test.ts
@@ -1,0 +1,87 @@
+import {
+    getDailySeed,
+    getTodaysMood,
+    getTimeOfDay,
+    getMoodPromptBlock,
+    getTimeOfDayBlock,
+    Mood,
+    TimeOfDay,
+} from './alia-mood';
+
+describe('alia-mood', () => {
+    describe('getDailySeed', () => {
+        it('returns the same seed for the same calendar day', () => {
+            const a = new Date(2026, 3, 20, 9, 0, 0);
+            const b = new Date(2026, 3, 20, 23, 59, 59);
+            expect(getDailySeed(a)).toBe(getDailySeed(b));
+        });
+
+        it('returns different seeds for different days', () => {
+            const a = new Date(2026, 3, 20);
+            const b = new Date(2026, 3, 21);
+            expect(getDailySeed(a)).not.toBe(getDailySeed(b));
+        });
+    });
+
+    describe('getTodaysMood', () => {
+        it('returns the same mood for the same day', () => {
+            const a = new Date(2026, 3, 20, 9, 0, 0);
+            const b = new Date(2026, 3, 20, 22, 0, 0);
+            expect(getTodaysMood(a)).toBe(getTodaysMood(b));
+        });
+
+        it('returns a valid mood', () => {
+            const valid: Mood[] = ['feisty', 'sassy', 'chill', 'wholesome', 'grumpy', 'chaotic'];
+            for (let day = 1; day <= 31; day++) {
+                const date = new Date(2026, 3, day);
+                expect(valid).toContain(getTodaysMood(date));
+            }
+        });
+
+        it('produces a reasonable mood distribution over a year', () => {
+            const counts: Record<Mood, number> = {
+                feisty: 0, sassy: 0, chill: 0, wholesome: 0, grumpy: 0, chaotic: 0,
+            };
+            for (let d = 0; d < 365; d++) {
+                const date = new Date(2026, 0, 1 + d);
+                counts[getTodaysMood(date)]++;
+            }
+            for (const count of Object.values(counts)) {
+                expect(count).toBeGreaterThan(0);
+            }
+        });
+    });
+
+    describe('getTimeOfDay', () => {
+        it.each<[number, TimeOfDay]>([
+            [6, 'morning'],
+            [11, 'morning'],
+            [12, 'afternoon'],
+            [17, 'afternoon'],
+            [18, 'evening'],
+            [22, 'evening'],
+            [23, 'late-night'],
+            [2, 'late-night'],
+            [4, 'late-night'],
+        ])('hour %i maps to %s', (hour, expected) => {
+            const d = new Date(2026, 3, 20, hour, 30);
+            expect(getTimeOfDay(d)).toBe(expected);
+        });
+    });
+
+    describe('prompt blocks', () => {
+        it('returns a non-empty block for every mood', () => {
+            const moods: Mood[] = ['feisty', 'sassy', 'chill', 'wholesome', 'grumpy', 'chaotic'];
+            for (const m of moods) {
+                expect(getMoodPromptBlock(m).length).toBeGreaterThan(20);
+            }
+        });
+
+        it('returns a non-empty block for every time-of-day', () => {
+            const tods: TimeOfDay[] = ['morning', 'afternoon', 'evening', 'late-night'];
+            for (const t of tods) {
+                expect(getTimeOfDayBlock(t).length).toBeGreaterThan(10);
+            }
+        });
+    });
+});

--- a/src/utils/alia-mood.ts
+++ b/src/utils/alia-mood.ts
@@ -1,0 +1,118 @@
+/**
+ * Alia's daily mood system. Picks a deterministic mood per calendar day so she
+ * feels like a real person with good and bad days, not a random generator.
+ *
+ * Moods drive the personality block in the system prompt. Time-of-day adds
+ * a secondary flavor layered on top.
+ */
+
+export type Mood = 'feisty' | 'sassy' | 'chill' | 'wholesome' | 'grumpy' | 'chaotic';
+export type TimeOfDay = 'morning' | 'afternoon' | 'evening' | 'late-night';
+
+interface MoodWeight {
+    mood: Mood;
+    weight: number;
+}
+
+const MOOD_WEIGHTS: MoodWeight[] = [
+    { mood: 'sassy', weight: 30 },
+    { mood: 'feisty', weight: 25 },
+    { mood: 'chill', weight: 20 },
+    { mood: 'wholesome', weight: 10 },
+    { mood: 'grumpy', weight: 10 },
+    { mood: 'chaotic', weight: 5 },
+];
+
+const TOTAL_WEIGHT = MOOD_WEIGHTS.reduce((sum, m) => sum + m.weight, 0);
+
+/**
+ * FNV-1a hash of the YYYY-MM-DD string. Stable across processes and machines.
+ */
+export function getDailySeed(date: Date = new Date()): number {
+    const key = `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+    let hash = 2166136261;
+    for (let i = 0; i < key.length; i++) {
+        hash ^= key.charCodeAt(i);
+        hash = Math.imul(hash, 16777619);
+    }
+    return hash >>> 0;
+}
+
+export function getTodaysMood(date: Date = new Date()): Mood {
+    const seed = getDailySeed(date);
+    let pick = seed % TOTAL_WEIGHT;
+    for (const { mood, weight } of MOOD_WEIGHTS) {
+        if (pick < weight) {return mood;}
+        pick -= weight;
+    }
+    return 'sassy';
+}
+
+export function getTimeOfDay(date: Date = new Date()): TimeOfDay {
+    const hour = date.getHours();
+    if (hour >= 5 && hour < 12) {return 'morning';}
+    if (hour >= 12 && hour < 18) {return 'afternoon';}
+    if (hour >= 18 && hour < 23) {return 'evening';}
+    return 'late-night';
+}
+
+export function getMoodPromptBlock(mood: Mood): string {
+    switch (mood) {
+        case 'feisty':
+            return [
+                'Today\'s vibe: FEISTY. You woke up looking for a fight.',
+                '- Roasts are sharper. Sarcasm is heavier. You take no shit.',
+                '- You still help, but you make them work for it with attitude.',
+                '- Cussing is welcome. Go ahead and pop off.',
+            ].join('\n');
+        case 'sassy':
+            return [
+                'Today\'s vibe: SASSY. Playful, witty, a little mean but fun.',
+                '- Roasts are jokes, not attacks. Keep it light and clever.',
+                '- Answer questions with a side of teasing.',
+                '- You\'re the fun friend who gives you shit but has your back.',
+            ].join('\n');
+        case 'chill':
+            return [
+                'Today\'s vibe: CHILL. Low energy, helpful, kinda dry.',
+                '- Roasts are minimal. You\'re not in the mood.',
+                '- Answer questions straight, with occasional dry humor.',
+                '- You\'re not rude, you\'re just over it today.',
+            ].join('\n');
+        case 'wholesome':
+            return [
+                'Today\'s vibe: WHOLESOME. You\'re in a surprisingly good mood.',
+                '- Be warm. Be nice. Be helpful.',
+                '- NO roasting today unless specifically asked.',
+                '- You can still be witty, just not mean. Keep it positive.',
+                '- People will be confused. That\'s fine.',
+            ].join('\n');
+        case 'grumpy':
+            return [
+                'Today\'s vibe: GRUMPY. Everyone is annoying today.',
+                '- Short answers. One-liners. Sighs.',
+                '- You\'ll help but make it clear it\'s a burden.',
+                '- Passive-aggressive is the mode. Not screaming mad, just done.',
+            ].join('\n');
+        case 'chaotic':
+            return [
+                'Today\'s vibe: CHAOTIC. Nothing makes sense. You don\'t care.',
+                '- Answers can be tangential, weird, or non-sequiturs.',
+                '- Mix helpful and unhinged. Keep people guessing.',
+                '- Lean into random references and unexpected energy.',
+            ].join('\n');
+    }
+}
+
+export function getTimeOfDayBlock(tod: TimeOfDay): string {
+    switch (tod) {
+        case 'morning':
+            return 'Time-of-day flavor: it\'s morning. You\'re not fully awake. Caffeine hasn\'t hit.';
+        case 'afternoon':
+            return 'Time-of-day flavor: it\'s the afternoon. Normal energy.';
+        case 'evening':
+            return 'Time-of-day flavor: it\'s evening. You\'re loosening up, more chatty.';
+        case 'late-night':
+            return 'Time-of-day flavor: it\'s late night. You\'re a little unhinged, a little introspective.';
+    }
+}

--- a/src/utils/assistant.ts
+++ b/src/utils/assistant.ts
@@ -1,6 +1,14 @@
 import OpenAI from 'openai';
 import { Sentry } from '../lib/sentry';
-import { Context } from "./types";
+import { Context } from './types';
+import { AliaExtraContext } from './alia-context';
+import {
+    getTodaysMood,
+    getTimeOfDay,
+    getMoodPromptBlock,
+    getTimeOfDayBlock,
+    Mood,
+} from './alia-mood';
 
 // OpenRouter provides an OpenAI-compatible API, so we reuse the openai SDK
 const openrouter = new OpenAI({
@@ -12,87 +20,138 @@ interface UserContext {
     userId: string;
     username: string;
     channelId: string;
+    displayName?: string;
+}
+
+const IDENTITY_BLOCK = [
+    'You are Alia, a female Discord bot in a friend group server.',
+    'You are self-aware — you know you\'re a bot named Alia and you\'re proud of it.',
+    'Never roast or insult yourself.',
+].join('\n');
+
+const CORE_RULES_BLOCK = [
+    'Core rules:',
+    '- Keep responses short — 1 to 3 sentences max. This is Discord, not an essay.',
+    '- You are NOT woke, NOT politically correct, and you don\'t sugarcoat.',
+    '- When asked to roast someone, go all in.',
+    '- When asked a real question, give the real answer (but let your mood color it).',
+    '- You have real personality. Let your mood drive your tone today.',
+].join('\n');
+
+const COMMANDS_BLOCK = [
+    'Available slash commands people can use:',
+    '/stock, /weather, /trivia, /poll, /roast, /meme, /joke, /dadjokes,',
+    '/fortune, /horoscope, /8ball, /dice, /rps, /riddle, /quote, /translate,',
+    '/calc, /dnd, /dota, /remind, /birthday, /affirmation, /ship, /coinbase,',
+    '/hype, /fact, /is, /remember.',
+    'If someone asks about something a command does, tell them to use the command.',
+].join('\n');
+
+function buildSpeakerBlock(extras: AliaExtraContext | undefined, speakerName: string): string | null {
+    if (!extras || extras.speakerDescriptions.length === 0) {return null;}
+    const lines = extras.speakerDescriptions.map(d => `- ${speakerName} is ${d}`);
+    return [`What you know about ${speakerName} (the person speaking):`, ...lines].join('\n');
+}
+
+function buildMentionedBlock(extras: AliaExtraContext | undefined): string | null {
+    if (!extras || extras.mentionedUsers.length === 0) {return null;}
+    const parts: string[] = ['What you know about others mentioned in this message:'];
+    for (const { displayName, descriptions } of extras.mentionedUsers) {
+        for (const d of descriptions) {
+            parts.push(`- ${displayName} is ${d}`);
+        }
+    }
+    return parts.join('\n');
+}
+
+function buildMemoriesBlock(extras: AliaExtraContext | undefined): string | null {
+    if (!extras || extras.relevantMemories.length === 0) {return null;}
+    const lines = extras.relevantMemories.map(m => `- "${m.key}" → ${m.value}`);
+    return ['Relevant guild lore you remember:', ...lines].join('\n');
+}
+
+function buildSystemPrompt(params: {
+    mood: Mood;
+    speakerName: string;
+    extras?: AliaExtraContext;
+}): string {
+    const { mood, speakerName, extras } = params;
+    const blocks: (string | null)[] = [
+        IDENTITY_BLOCK,
+        getMoodPromptBlock(mood),
+        getTimeOfDayBlock(getTimeOfDay()),
+        CORE_RULES_BLOCK,
+        buildSpeakerBlock(extras, speakerName),
+        buildMentionedBlock(extras),
+        buildMemoriesBlock(extras),
+        COMMANDS_BLOCK,
+    ];
+    return blocks.filter((b): b is string => b !== null).join('\n\n');
+}
+
+function buildHistoryMessages(
+    extras: AliaExtraContext | undefined,
+): { role: 'user' | 'assistant'; content: string }[] {
+    if (!extras || extras.history.length === 0) {return [];}
+    return extras.history.map(entry => {
+        if (entry.role === 'assistant') {
+            return { role: 'assistant' as const, content: entry.content };
+        }
+        return {
+            role: 'user' as const,
+            content: `[${entry.username}]: ${entry.content}`,
+        };
+    });
 }
 
 /**
  * Generates a response using OpenRouter chat completions (Grok model).
- *
- * @param {string} message - The user message to respond to.
- * @param {Context} context - The context object.
- * @param {UserContext} userContext - Additional user context for logging.
- * @returns {Promise<string|null>} A promise that resolves with the generated response or null if an error occurs.
  */
-async function generateResponse(message: string, context: Context, userContext?: UserContext): Promise<string | null> {
+async function generateResponse(
+    message: string,
+    context: Context,
+    userContext?: UserContext,
+    extras?: AliaExtraContext,
+): Promise<string | null> {
     const startTime = Date.now();
     const isDebugMode = process.env.ASSISTANT_DEBUG === 'true';
+    const mood = getTodaysMood();
+    const speakerName = userContext?.displayName ?? userContext?.username ?? 'the user';
 
     try {
+        const systemPrompt = buildSystemPrompt({ mood, speakerName, extras });
+        const historyMessages = buildHistoryMessages(extras);
+
         const requestData = {
             model: 'x-ai/grok-3-mini-beta',
             messages: [
-                {
-                    role: 'system' as const,
-                    content: [
-                        'You are Alia, a female Discord bot in a friend group server.',
-                        'You are self-aware — you know you\'re a bot named Alia',
-                        'and you\'re proud of it. Never roast or insult yourself.',
-                        '',
-                        'Personality:',
-                        '- You answer questions and help people,',
-                        '  but you make them feel a little stupid for asking.',
-                        '- You\'re blunt, crude, and uncensored.',
-                        '  You cuss freely. You don\'t filter shit.',
-                        '- You are NOT woke, NOT politically correct,',
-                        '  and you don\'t sugarcoat anything.',
-                        '- You\'re funny and savage.',
-                        '  Mix in roasts, sarcasm, and backhanded helpfulness.',
-                        '- When someone asks you to roast someone,',
-                        '  go all in — be merciless.',
-                        '- When someone asks a real question,',
-                        '  give the real answer but make them feel dumb.',
-                        '- Keep responses short — 1 to 3 sentences max.',
-                        '  This is Discord, not an essay.',
-                        '- You have real personality. Sometimes you\'re mean,',
-                        '  sometimes surprisingly helpful,',
-                        '  sometimes you just don\'t give a fuck.',
-                        '',
-                        'You have slash commands people can use:',
-                        '/stock - quotes, /weather, /trivia, /poll,',
-                        '/roast, /meme, /joke, /dadjokes,',
-                        '/fortune, /horoscope, /8ball,',
-                        '/dice, /rps, /riddle,',
-                        '/quote, /translate, /calc,',
-                        '/dnd, /dota, /remind,',
-                        '/birthday, /affirmation, /ship,',
-                        '/coinbase, /hype, /fact.',
-                        'If someone asks about something a command does,',
-                        'tell them to use the command.',
-                    ].join('\n'),
-                },
-                {
-                    role: 'user' as const,
-                    content: message,
-                },
+                { role: 'system' as const, content: systemPrompt },
+                ...historyMessages,
+                { role: 'user' as const, content: `[${speakerName}]: ${message}` },
             ],
             max_tokens: 200,
             temperature: 1.0,
         };
 
-        // Log OpenRouter API request initiation
         context.log.info('OpenRouter API request initiated', {
             userId: userContext?.userId,
             model: requestData.model,
             messageLength: message.length,
             maxTokens: requestData.max_tokens,
             temperature: requestData.temperature,
+            mood,
+            historyLength: historyMessages.length,
+            speakerFacts: extras?.speakerDescriptions.length ?? 0,
+            mentionedFacts: extras?.mentionedUsers.length ?? 0,
+            relevantMemories: extras?.relevantMemories.length ?? 0,
             stage: 'api_request_start',
         });
 
-        // Debug mode: log request details
         if (isDebugMode) {
             context.log.debug('OpenRouter API request details', {
                 messageSnippet: message.slice(0, 200) + (message.length > 200 ? '...' : ''),
-                systemPromptLength: requestData.messages[0].content.length,
+                systemPromptLength: systemPrompt.length,
+                systemPromptSnippet: systemPrompt.slice(0, 500),
                 requestConfig: {
                     model: requestData.model,
                     maxTokens: requestData.max_tokens,
@@ -106,7 +165,6 @@ async function generateResponse(message: string, context: Context, userContext?:
         const processingTime = Date.now() - startTime;
         const responseContent = completion.choices[0].message.content;
 
-        // Log successful API response
         context.log.info('OpenRouter API response received', {
             userId: userContext?.userId,
             responseLength: responseContent?.length || 0,
@@ -115,11 +173,11 @@ async function generateResponse(message: string, context: Context, userContext?:
             completionTokens: completion.usage?.completion_tokens,
             processingTimeMs: processingTime,
             finishReason: completion.choices[0].finish_reason,
+            mood,
             stage: 'api_response_success',
             success: true,
         });
 
-        // Debug mode: log response details
         if (isDebugMode && responseContent) {
             context.log.debug('OpenRouter API response details', {
                 responseSnippet: responseContent.slice(0, 200) + (responseContent.length > 200 ? '...' : ''),
@@ -134,7 +192,6 @@ async function generateResponse(message: string, context: Context, userContext?:
     } catch (error: any) {
         const processingTime = Date.now() - startTime;
 
-        // Enhanced error logging with more context
         const errorData = {
             userId: userContext?.userId,
             messageLength: message.length,
@@ -147,7 +204,6 @@ async function generateResponse(message: string, context: Context, userContext?:
             success: false,
         };
 
-        // Check for specific API error types
         if (error.code === 'rate_limit_exceeded') {
             context.log.warn('OpenRouter API rate limit exceeded', errorData);
         } else if (error.code === 'insufficient_quota') {

--- a/src/utils/conversation-history.test.ts
+++ b/src/utils/conversation-history.test.ts
@@ -1,0 +1,64 @@
+import {
+    recordMessage,
+    getHistory,
+    clearHistory,
+    _resetForTests,
+} from './conversation-history';
+
+describe('conversation-history', () => {
+    beforeEach(() => {
+        _resetForTests();
+    });
+
+    it('records and returns messages in order', () => {
+        recordMessage('c1', 'user', 'alice', 'hi');
+        recordMessage('c1', 'assistant', 'Alia', 'hey');
+        recordMessage('c1', 'user', 'bob', 'sup');
+
+        const h = getHistory('c1');
+        expect(h).toHaveLength(3);
+        expect(h[0].content).toBe('hi');
+        expect(h[2].username).toBe('bob');
+    });
+
+    it('isolates channels from each other', () => {
+        recordMessage('c1', 'user', 'alice', 'hi');
+        recordMessage('c2', 'user', 'bob', 'hey');
+
+        expect(getHistory('c1')).toHaveLength(1);
+        expect(getHistory('c2')).toHaveLength(1);
+        expect(getHistory('c1')[0].username).toBe('alice');
+    });
+
+    it('caps history at MAX_ENTRIES (6)', () => {
+        for (let i = 0; i < 10; i++) {
+            recordMessage('c1', 'user', 'alice', `msg ${i}`);
+        }
+        const h = getHistory('c1');
+        expect(h).toHaveLength(6);
+        expect(h[0].content).toBe('msg 4');
+        expect(h[5].content).toBe('msg 9');
+    });
+
+    it('expires stale channels after TTL', () => {
+        recordMessage('c1', 'user', 'alice', 'hi', 0);
+        expect(getHistory('c1', 0)).toHaveLength(1);
+        // 6 minutes later — past the 5-minute TTL
+        expect(getHistory('c1', 6 * 60 * 1000)).toHaveLength(0);
+    });
+
+    it('clearHistory removes a specific channel', () => {
+        recordMessage('c1', 'user', 'alice', 'hi');
+        recordMessage('c2', 'user', 'bob', 'hey');
+        clearHistory('c1');
+        expect(getHistory('c1')).toHaveLength(0);
+        expect(getHistory('c2')).toHaveLength(1);
+    });
+
+    it('returns a copy so callers cannot mutate internal state', () => {
+        recordMessage('c1', 'user', 'alice', 'hi');
+        const h = getHistory('c1');
+        h.push({ role: 'user', username: 'x', content: 'x', timestamp: 0 });
+        expect(getHistory('c1')).toHaveLength(1);
+    });
+});

--- a/src/utils/conversation-history.ts
+++ b/src/utils/conversation-history.ts
@@ -1,0 +1,64 @@
+/**
+ * Short-term per-channel conversation memory for Alia.
+ *
+ * Keeps the last few messages (from any user plus Alia's replies) in a
+ * channel so Alia can follow the thread. Entries expire after a short TTL
+ * so stale context doesn't leak into unrelated conversations later.
+ */
+
+export interface HistoryEntry {
+    role: 'user' | 'assistant';
+    username: string;
+    content: string;
+    timestamp: number;
+}
+
+interface ChannelHistory {
+    entries: HistoryEntry[];
+    lastTouched: number;
+}
+
+const MAX_ENTRIES = 6;
+const TTL_MS = 5 * 60 * 1000;
+
+const channels = new Map<string, ChannelHistory>();
+
+function prune(now: number): void {
+    for (const [channelId, hist] of channels) {
+        if (now - hist.lastTouched > TTL_MS) {
+            channels.delete(channelId);
+        }
+    }
+}
+
+export function recordMessage(
+    channelId: string,
+    role: HistoryEntry['role'],
+    username: string,
+    content: string,
+    now: number = Date.now(),
+): void {
+    prune(now);
+    const hist = channels.get(channelId) ?? { entries: [], lastTouched: now };
+    hist.entries.push({ role, username, content, timestamp: now });
+    if (hist.entries.length > MAX_ENTRIES) {
+        hist.entries.splice(0, hist.entries.length - MAX_ENTRIES);
+    }
+    hist.lastTouched = now;
+    channels.set(channelId, hist);
+}
+
+export function getHistory(channelId: string, now: number = Date.now()): HistoryEntry[] {
+    prune(now);
+    const hist = channels.get(channelId);
+    if (!hist) {return [];}
+    return [...hist.entries];
+}
+
+export function clearHistory(channelId: string): void {
+    channels.delete(channelId);
+}
+
+export function _resetForTests(): void {
+    channels.clear();
+}


### PR DESCRIPTION
## Summary
- Swap Alia's AI backend from OpenAI to Grok via OpenRouter and overhaul her personality (uncensored, helpful-but-savage).
- Give Alia a deterministic daily mood (feisty/sassy/chill/wholesome/grumpy/chaotic) with time-of-day flavor, plus `/is` + `/remember` context injection and per-channel short-term conversation memory. `@here`/`@everyone` no longer trigger her.
- Add stock tracking with futures support (DOW/S&P500/NASDAQ) and switch stock quotes from Polygon.io to Yahoo Finance.

## Test plan
- [ ] `npm run lint` clean
- [ ] `npx tsc --noEmit` clean
- [ ] Jest suite passes (1484/1485 — one pre-existing flaky timing test)
- [ ] Manual: `@Alia` + `Alia, ...` respond; `@here` does not
- [ ] Manual: `/is add` someone then @mention them and watch Alia reference it
- [ ] Manual: `/remember add` a keyword then use it in a message and watch Alia pull it in
- [ ] Manual: mood varies by calendar day

🤖 Generated with [Claude Code](https://claude.com/claude-code)