### PR TITLE
feat(assistant): relationship scoring + auto-learn via /is

### DIFF
--- a/migrations/20260420000000-create-user-interactions-table.js
+++ b/migrations/20260420000000-create-user-interactions-table.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.createTable('user_interactions', {
+            id: {
+                type: Sequelize.INTEGER,
+                primaryKey: true,
+                autoIncrement: true,
+                allowNull: false,
+            },
+            guild_id: {
+                type: Sequelize.STRING,
+                allowNull: false,
+            },
+            user_id: {
+                type: Sequelize.STRING,
+                allowNull: false,
+                comment: 'The Discord user who interacted with Alia',
+            },
+            interaction_count: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+                defaultValue: 0,
+            },
+            last_interaction_at: {
+                type: Sequelize.DATE,
+                allowNull: false,
+            },
+            created_at: {
+                type: Sequelize.DATE,
+                allowNull: false,
+            },
+            updated_at: {
+                type: Sequelize.DATE,
+                allowNull: false,
+            },
+        });
+
+        await queryInterface.addIndex('user_interactions', ['guild_id', 'user_id'], {
+            unique: true,
+            name: 'user_interactions_unique',
+        });
+    },
+
+    async down(queryInterface) {
+        await queryInterface.removeIndex('user_interactions', 'user_interactions_unique');
+        await queryInterface.dropTable('user_interactions');
+    },
+};

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -18,6 +18,7 @@ import VerificationCode from "./verificationCode";
 import Password from "./password";
 import ScheduledEvent from "./scheduledEvent";
 import UserDescriptions from "./userDescriptions";
+import UserInteractions from "./userInteractions";
 import SparksUser from "./sparksUser";
 import SparksBalance from "./sparksBalance";
 import SparksLedger from "./sparksLedger";
@@ -50,6 +51,7 @@ export default {
     Password,
     ScheduledEvent,
     UserDescriptions,
+    UserInteractions,
     SparksUser,
     SparksBalance,
     SparksLedger,

--- a/src/models/userInteractions.ts
+++ b/src/models/userInteractions.ts
@@ -1,0 +1,50 @@
+import { DataTypes } from 'sequelize';
+
+export default (sequelize: any) => ({
+    UserInteractions: sequelize.define('UserInteractions', {
+        id: {
+            type: DataTypes.INTEGER,
+            primaryKey: true,
+            autoIncrement: true,
+        },
+        guild_id: {
+            type: DataTypes.STRING,
+            allowNull: false,
+        },
+        user_id: {
+            type: DataTypes.STRING,
+            allowNull: false,
+            comment: 'The Discord user who interacted with Alia',
+        },
+        interaction_count: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            defaultValue: 0,
+        },
+        last_interaction_at: {
+            type: DataTypes.DATE,
+            allowNull: false,
+            defaultValue: DataTypes.NOW,
+        },
+        created_at: {
+            type: DataTypes.DATE,
+            defaultValue: DataTypes.NOW,
+        },
+        updated_at: {
+            type: DataTypes.DATE,
+            defaultValue: DataTypes.NOW,
+        },
+    }, {
+        tableName: 'user_interactions',
+        timestamps: true,
+        createdAt: 'created_at',
+        updatedAt: 'updated_at',
+        indexes: [
+            {
+                unique: true,
+                fields: ['guild_id', 'user_id'],
+                name: 'user_interactions_unique',
+            },
+        ],
+    }),
+});

--- a/src/responses/assistant.test.ts
+++ b/src/responses/assistant.test.ts
@@ -10,7 +10,17 @@ jest.mock('../utils/alia-context', () => ({
         mentionedUsers: [],
         relevantMemories: [],
         history: [],
+        relationship: {
+            count: 0, tier: 'stranger', lastInteractionAt: null, hoursSinceLast: null,
+        },
+        knownUsers: [],
     }),
+}));
+jest.mock('../utils/alia-relationships', () => ({
+    bumpInteraction: jest.fn().mockResolvedValue(undefined),
+    classifyTier: jest.fn(),
+    describeRelationship: jest.fn().mockReturnValue(''),
+    getInteractionInfo: jest.fn(),
 }));
 
 import assistantResponse from './assistant';

--- a/src/responses/assistant.ts
+++ b/src/responses/assistant.ts
@@ -4,14 +4,14 @@ import { Context } from '../utils/types';
 import { safelySendToChannel } from '../utils/discordHelpers';
 import { gatherAliaContext } from '../utils/alia-context';
 import { recordMessage } from '../utils/conversation-history';
+import { parseRememberMarkers, persistMarkers } from '../utils/alia-learn';
+import { bumpInteraction } from '../utils/alia-relationships';
 
 export default async (message: Message, context: Context): Promise<boolean> => {
     if (message.author.bot) {
         return false;
     }
 
-    // Only process messages that explicitly address the bot.
-    // ignoreEveryone prevents @here / @everyone from looking like a direct mention.
     const content = message.content.toLowerCase().trim();
     const botMentioned = message.client.user
         ? message.mentions.has(message.client.user, {
@@ -46,12 +46,9 @@ export default async (message: Message, context: Context): Promise<boolean> => {
     });
 
     try {
-        const extras = await gatherAliaContext(message, context);
+        const extras = await gatherAliaContext(message, context, speakerName);
 
-        // Record the incoming message in history BEFORE calling generateResponse
-        // so the model sees it as the latest user turn via the explicit user
-        // message, and sees prior context via history.
-        const response = await generateResponse(
+        const rawResponse = await generateResponse(
             processableContent,
             context,
             {
@@ -63,23 +60,49 @@ export default async (message: Message, context: Context): Promise<boolean> => {
             extras,
         );
 
-        if (response && message.channel && 'send' in message.channel) {
+        if (rawResponse && message.channel && 'send' in message.channel) {
+            // Extract any auto-learn markers and persist them.
+            const { markers, cleaned } = parseRememberMarkers(rawResponse);
+            const allowedUserIds = new Set(extras.knownUsers.map(u => u.userId));
+            const guildId = message.guildId;
+            if (markers.length > 0 && guildId) {
+                const saved = await persistMarkers(
+                    context, markers, guildId, message.author.id, allowedUserIds,
+                );
+                context.log.info('Auto-learn persisted markers', {
+                    userId: message.author.id,
+                    attempted: markers.length,
+                    saved,
+                });
+            }
+
+            // If the model only returned markers and no prose, send a fallback.
+            const toSend = cleaned.length > 0 ? cleaned : 'Noted.';
+
             const success = await safelySendToChannel(
                 message.channel as any,
-                response,
+                toSend,
                 context,
                 'assistant response',
             );
 
             const processingTime = Date.now() - startTime;
             if (success) {
-                // Only persist turns we actually delivered.
                 recordMessage(message.channelId, 'user', speakerName, processableContent);
-                recordMessage(message.channelId, 'assistant', 'Alia', response);
+                recordMessage(message.channelId, 'assistant', 'Alia', toSend);
+
+                if (guildId) {
+                    try {
+                        await bumpInteraction(context.tables, guildId, message.author.id);
+                    } catch (error) {
+                        context.log.warn('Failed to bump interaction count', { error });
+                    }
+                }
 
                 context.log.info('Assistant response sent', {
                     userId: message.author.id,
-                    responseLength: response.length,
+                    responseLength: toSend.length,
+                    markersSaved: markers.length,
                     processingTimeMs: processingTime,
                 });
                 return true;

--- a/src/utils/alia-context.test.ts
+++ b/src/utils/alia-context.test.ts
@@ -15,6 +15,9 @@ describe('gatherAliaContext', () => {
                 Memories: {
                     findAll: jest.fn().mockResolvedValue([]),
                 },
+                UserInteractions: {
+                    findOne: jest.fn().mockResolvedValue(null),
+                },
                 ...overrides.tables,
             },
             log: { warn: jest.fn(), info: jest.fn(), debug: jest.fn(), error: jest.fn() },
@@ -42,7 +45,7 @@ describe('gatherAliaContext', () => {
             { description: 'always late' },
         ]);
 
-        const result = await gatherAliaContext(buildMessage(), ctx);
+        const result = await gatherAliaContext(buildMessage(), ctx, 'Speaker');
 
         expect(result.speakerDescriptions).toEqual(['a badass guitarist', 'always late']);
         expect(ctx.tables.UserDescriptions.findAll).toHaveBeenCalledWith({
@@ -63,10 +66,10 @@ describe('gatherAliaContext', () => {
         mentionedUsers.set('u-other', { id: 'u-other', username: 'Derek' });
 
         const msg = buildMessage({ mentionedUsers });
-        const result = await gatherAliaContext(msg, ctx);
+        const result = await gatherAliaContext(msg, ctx, 'Speaker');
 
         expect(result.mentionedUsers).toEqual([
-            { displayName: 'Derek', descriptions: ['the one who pays'] },
+            { userId: 'u-other', displayName: 'Derek', descriptions: ['the one who pays'] },
         ]);
     });
 
@@ -79,7 +82,7 @@ describe('gatherAliaContext', () => {
         ]);
 
         const msg = buildMessage({ content: 'hello world, are you playing dota tonight?' });
-        const result = await gatherAliaContext(msg, ctx);
+        const result = await gatherAliaContext(msg, ctx, 'Speaker');
 
         const keys = result.relevantMemories.map(m => m.key);
         expect(keys).toContain('dota');
@@ -93,14 +96,14 @@ describe('gatherAliaContext', () => {
             { key: 'a', value: 'too short' },
             { key: 'ok', value: 'also too short' },
         ]);
-        const result = await gatherAliaContext(buildMessage({ content: 'a ok' }), ctx);
+        const result = await gatherAliaContext(buildMessage({ content: 'a ok' }), ctx, 'Speaker');
         expect(result.relevantMemories).toHaveLength(0);
     });
 
     it('includes channel history', async () => {
         recordMessage('c1', 'user', 'alice', 'earlier');
         const ctx = buildContext();
-        const result = await gatherAliaContext(buildMessage(), ctx);
+        const result = await gatherAliaContext(buildMessage(), ctx, 'Speaker');
         expect(result.history).toHaveLength(1);
         expect(result.history[0].content).toBe('earlier');
     });
@@ -108,7 +111,7 @@ describe('gatherAliaContext', () => {
     it('returns empty context when not in a guild', async () => {
         const ctx = buildContext();
         const msg = buildMessage({ guildId: null });
-        const result = await gatherAliaContext(msg, ctx);
+        const result = await gatherAliaContext(msg, ctx, 'Speaker');
         expect(result.speakerDescriptions).toEqual([]);
         expect(result.mentionedUsers).toEqual([]);
         expect(ctx.tables.UserDescriptions.findAll).not.toHaveBeenCalled();
@@ -117,7 +120,7 @@ describe('gatherAliaContext', () => {
     it('swallows errors and returns safe defaults', async () => {
         const ctx = buildContext();
         ctx.tables.UserDescriptions.findAll.mockRejectedValueOnce(new Error('db down'));
-        const result = await gatherAliaContext(buildMessage(), ctx);
+        const result = await gatherAliaContext(buildMessage(), ctx, 'Speaker');
         expect(result.speakerDescriptions).toEqual([]);
         expect(ctx.log.warn).toHaveBeenCalled();
     });

--- a/src/utils/alia-context.ts
+++ b/src/utils/alia-context.ts
@@ -1,10 +1,17 @@
 import { Message } from 'discord.js';
 import { Context } from './types';
 import { getHistory, HistoryEntry } from './conversation-history';
+import { getInteractionInfo, InteractionInfo } from './alia-relationships';
 
 export interface MentionedUserContext {
+    userId: string;
     displayName: string;
     descriptions: string[];
+}
+
+export interface KnownUser {
+    userId: string;
+    displayName: string;
 }
 
 export interface AliaExtraContext {
@@ -12,6 +19,8 @@ export interface AliaExtraContext {
     mentionedUsers: MentionedUserContext[];
     relevantMemories: { key: string; value: string }[];
     history: HistoryEntry[];
+    relationship: InteractionInfo;
+    knownUsers: KnownUser[];
 }
 
 const MAX_DESCRIPTIONS_PER_USER = 5;
@@ -52,6 +61,7 @@ async function findRelevantMemories(
 export async function gatherAliaContext(
     message: Message,
     context: Context,
+    speakerDisplayName: string,
 ): Promise<AliaExtraContext> {
     const { tables, log } = context;
     const guildId = message.guildId;
@@ -61,11 +71,18 @@ export async function gatherAliaContext(
         mentionedUsers: [],
         relevantMemories: [],
         history: getHistory(message.channelId),
+        relationship: {
+            count: 0, tier: 'stranger', lastInteractionAt: null, hoursSinceLast: null,
+        },
+        knownUsers: [{ userId: message.author.id, displayName: speakerDisplayName }],
     };
 
     try {
         if (guildId) {
             result.speakerDescriptions = await fetchDescriptions(
+                tables, guildId, message.author.id,
+            );
+            result.relationship = await getInteractionInfo(
                 tables, guildId, message.author.id,
             );
 
@@ -77,11 +94,13 @@ export async function gatherAliaContext(
             });
 
             for (const userId of mentionedIds) {
-                const descriptions = await fetchDescriptions(tables, guildId, userId);
-                if (descriptions.length === 0) {continue;}
                 const member = message.mentions.users.get(userId);
                 const displayName = member?.username ?? userId;
-                result.mentionedUsers.push({ displayName, descriptions });
+                result.knownUsers.push({ userId, displayName });
+
+                const descriptions = await fetchDescriptions(tables, guildId, userId);
+                if (descriptions.length === 0) {continue;}
+                result.mentionedUsers.push({ userId, displayName, descriptions });
             }
         }
 

--- a/src/utils/alia-learn.test.ts
+++ b/src/utils/alia-learn.test.ts
@@ -1,0 +1,108 @@
+import { parseRememberMarkers, persistMarkers } from './alia-learn';
+
+describe('parseRememberMarkers', () => {
+    it('extracts a single marker and strips it from text', () => {
+        const input = 'Got it. <REMEMBER user_id="123" description="a guitarist"/> Gross.';
+        const { markers, cleaned } = parseRememberMarkers(input);
+        expect(markers).toEqual([{ userId: '123', description: 'a guitarist' }]);
+        expect(cleaned).toBe('Got it. Gross.');
+    });
+
+    it('extracts multiple markers', () => {
+        const input = '<REMEMBER user_id="1" description="foo"/><REMEMBER user_id="2" description="bar"/>Hey';
+        const { markers, cleaned } = parseRememberMarkers(input);
+        expect(markers).toHaveLength(2);
+        expect(cleaned).toBe('Hey');
+    });
+
+    it('returns empty markers when none present', () => {
+        const { markers, cleaned } = parseRememberMarkers('Just a reply.');
+        expect(markers).toEqual([]);
+        expect(cleaned).toBe('Just a reply.');
+    });
+
+    it('handles marker with or without self-closing slash', () => {
+        const input = '<REMEMBER user_id="1" description="foo">and<REMEMBER user_id="2" description="bar"/>done';
+        const { markers } = parseRememberMarkers(input);
+        expect(markers).toHaveLength(2);
+    });
+
+    it('is case-insensitive on the tag name', () => {
+        const { markers } = parseRememberMarkers('<remember user_id="1" description="foo"/>');
+        expect(markers).toHaveLength(1);
+    });
+
+    it('rejects descriptions that are too long', () => {
+        const longDesc = 'x'.repeat(201);
+        const input = `<REMEMBER user_id="1" description="${longDesc}"/>`;
+        const { markers, cleaned } = parseRememberMarkers(input);
+        expect(markers).toHaveLength(0);
+        expect(cleaned).toBe('');
+    });
+
+    it('rejects empty descriptions', () => {
+        const { markers } = parseRememberMarkers('<REMEMBER user_id="1" description=" "/>');
+        expect(markers).toHaveLength(0);
+    });
+});
+
+describe('persistMarkers', () => {
+    function buildContext() {
+        return {
+            tables: {
+                UserDescriptions: {
+                    findOrCreate: jest.fn().mockResolvedValue([{}, true]),
+                },
+            },
+            log: { warn: jest.fn(), info: jest.fn(), debug: jest.fn(), error: jest.fn() },
+        } as any;
+    }
+
+    it('persists markers for allowed user IDs', async () => {
+        const ctx = buildContext();
+        const saved = await persistMarkers(
+            ctx,
+            [{ userId: '1', description: 'foo' }, { userId: '2', description: 'bar' }],
+            'g1',
+            'speaker',
+            new Set(['1', '2']),
+        );
+        expect(saved).toBe(2);
+        expect(ctx.tables.UserDescriptions.findOrCreate).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects markers for user IDs not in the allowed set', async () => {
+        const ctx = buildContext();
+        const saved = await persistMarkers(
+            ctx,
+            [{ userId: '999', description: 'spoofed' }],
+            'g1',
+            'speaker',
+            new Set(['1', '2']),
+        );
+        expect(saved).toBe(0);
+        expect(ctx.tables.UserDescriptions.findOrCreate).not.toHaveBeenCalled();
+        expect(ctx.log.warn).toHaveBeenCalled();
+    });
+
+    it('continues after a single failure', async () => {
+        const ctx = buildContext();
+        ctx.tables.UserDescriptions.findOrCreate
+            .mockRejectedValueOnce(new Error('db'))
+            .mockResolvedValueOnce([{}, true]);
+        const saved = await persistMarkers(
+            ctx,
+            [{ userId: '1', description: 'foo' }, { userId: '2', description: 'bar' }],
+            'g1',
+            'speaker',
+            new Set(['1', '2']),
+        );
+        expect(saved).toBe(1);
+    });
+
+    it('returns 0 for empty marker list', async () => {
+        const ctx = buildContext();
+        const saved = await persistMarkers(ctx, [], 'g1', 'speaker', new Set());
+        expect(saved).toBe(0);
+    });
+});

--- a/src/utils/alia-learn.ts
+++ b/src/utils/alia-learn.ts
@@ -1,0 +1,77 @@
+import { Context } from './types';
+
+/**
+ * Auto-learn pipeline. Alia is instructed to embed machine-readable markers in
+ * her replies when a user asks her to remember a fact:
+ *
+ *   <REMEMBER user_id="123" description="a badass guitarist"/>
+ *
+ * We extract these markers, persist them to UserDescriptions, and strip them
+ * from the text that gets sent to Discord. The marker approach avoids the
+ * complexity of multi-turn tool calls and works on any model.
+ */
+
+export interface RememberMarker {
+    userId: string;
+    description: string;
+}
+
+export interface ParseResult {
+    markers: RememberMarker[];
+    cleaned: string;
+}
+
+const MARKER_RE = /<REMEMBER\s+user_id="([^"]+)"\s+description="([^"]+)"\s*\/?\s*>/gi;
+const MAX_DESCRIPTION_LENGTH = 200;
+
+export function parseRememberMarkers(text: string): ParseResult {
+    const markers: RememberMarker[] = [];
+    const cleaned = text.replace(MARKER_RE, (_match, userId: string, description: string) => {
+        const trimmed = description.trim();
+        if (trimmed.length > 0 && trimmed.length <= MAX_DESCRIPTION_LENGTH) {
+            markers.push({ userId: userId.trim(), description: trimmed });
+        }
+        return '';
+    }).replace(/\s+/g, ' ').trim();
+    return { markers, cleaned };
+}
+
+export async function persistMarkers(
+    context: Context,
+    markers: RememberMarker[],
+    guildId: string,
+    creatorId: string,
+    allowedUserIds: Set<string>,
+): Promise<number> {
+    if (markers.length === 0) {return 0;}
+    const { tables, log } = context;
+    let saved = 0;
+    for (const marker of markers) {
+        if (!allowedUserIds.has(marker.userId)) {
+            log.warn('Rejected auto-learn marker for non-conversation user', {
+                userId: marker.userId,
+                description: marker.description,
+            });
+            continue;
+        }
+        try {
+            await tables.UserDescriptions.findOrCreate({
+                where: {
+                    guild_id: guildId,
+                    user_id: marker.userId,
+                    description: marker.description,
+                },
+                defaults: {
+                    guild_id: guildId,
+                    user_id: marker.userId,
+                    description: marker.description,
+                    creator_id: creatorId,
+                },
+            });
+            saved += 1;
+        } catch (error) {
+            log.warn('Failed to persist auto-learn marker', { error, marker });
+        }
+    }
+    return saved;
+}

--- a/src/utils/alia-relationships.test.ts
+++ b/src/utils/alia-relationships.test.ts
@@ -1,0 +1,98 @@
+import {
+    classifyTier,
+    getInteractionInfo,
+    bumpInteraction,
+    describeRelationship,
+} from './alia-relationships';
+
+describe('alia-relationships', () => {
+    describe('classifyTier', () => {
+        it('classifies 0 as stranger', () => expect(classifyTier(0)).toBe('stranger'));
+        it('classifies 2 as stranger', () => expect(classifyTier(2)).toBe('stranger'));
+        it('classifies 3 as acquaintance', () => expect(classifyTier(3)).toBe('acquaintance'));
+        it('classifies 19 as acquaintance', () => expect(classifyTier(19)).toBe('acquaintance'));
+        it('classifies 20 as regular', () => expect(classifyTier(20)).toBe('regular'));
+        it('classifies 500 as regular', () => expect(classifyTier(500)).toBe('regular'));
+    });
+
+    describe('getInteractionInfo', () => {
+        it('returns zero-state for unknown user', async () => {
+            const tables = {
+                UserInteractions: { findOne: jest.fn().mockResolvedValue(null) },
+            } as any;
+            const info = await getInteractionInfo(tables, 'g', 'u');
+            expect(info).toEqual({
+                count: 0, tier: 'stranger', lastInteractionAt: null, hoursSinceLast: null,
+            });
+        });
+
+        it('computes tier and hoursSinceLast from row', async () => {
+            const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+            const tables = {
+                UserInteractions: {
+                    findOne: jest.fn().mockResolvedValue({
+                        interaction_count: 25,
+                        last_interaction_at: twoHoursAgo,
+                    }),
+                },
+            } as any;
+            const info = await getInteractionInfo(tables, 'g', 'u');
+            expect(info.count).toBe(25);
+            expect(info.tier).toBe('regular');
+            expect(info.hoursSinceLast).toBe(2);
+        });
+    });
+
+    describe('bumpInteraction', () => {
+        it('creates a new row for first-time user', async () => {
+            const findOrCreate = jest.fn().mockResolvedValue([
+                { interaction_count: 1, update: jest.fn() },
+                true,
+            ]);
+            const tables = { UserInteractions: { findOrCreate } } as any;
+            await bumpInteraction(tables, 'g', 'u');
+            expect(findOrCreate).toHaveBeenCalled();
+        });
+
+        it('increments existing row', async () => {
+            const update = jest.fn();
+            const row = { interaction_count: 5, update };
+            const tables = {
+                UserInteractions: {
+                    findOrCreate: jest.fn().mockResolvedValue([row, false]),
+                },
+            } as any;
+            await bumpInteraction(tables, 'g', 'u');
+            expect(update).toHaveBeenCalledWith(expect.objectContaining({
+                interaction_count: 6,
+            }));
+        });
+    });
+
+    describe('describeRelationship', () => {
+        it('handles never-talked case', () => {
+            const s = describeRelationship(
+                { count: 0, tier: 'stranger', lastInteractionAt: null, hoursSinceLast: null },
+                'Derek',
+            );
+            expect(s).toMatch(/never talked to Derek/);
+        });
+
+        it('mentions recent contact when within 24h', () => {
+            const s = describeRelationship(
+                { count: 50, tier: 'regular', lastInteractionAt: new Date(), hoursSinceLast: 3 },
+                'Derek',
+            );
+            expect(s).toMatch(/3h ago/);
+            expect(s).toMatch(/know them well/);
+        });
+
+        it('omits recent contact when over 24h', () => {
+            const s = describeRelationship(
+                { count: 50, tier: 'regular', lastInteractionAt: new Date(), hoursSinceLast: 72 },
+                'Derek',
+            );
+            expect(s).not.toMatch(/ago/);
+        });
+    });
+});

--- a/src/utils/alia-relationships.ts
+++ b/src/utils/alia-relationships.ts
@@ -1,0 +1,84 @@
+import { Context } from './types';
+
+export type Tier = 'stranger' | 'acquaintance' | 'regular';
+
+export interface InteractionInfo {
+    count: number;
+    tier: Tier;
+    lastInteractionAt: Date | null;
+    hoursSinceLast: number | null;
+}
+
+const ACQUAINTANCE_THRESHOLD = 3;
+const REGULAR_THRESHOLD = 20;
+
+export function classifyTier(count: number): Tier {
+    if (count < ACQUAINTANCE_THRESHOLD) {return 'stranger';}
+    if (count < REGULAR_THRESHOLD) {return 'acquaintance';}
+    return 'regular';
+}
+
+export async function getInteractionInfo(
+    tables: Context['tables'],
+    guildId: string,
+    userId: string,
+): Promise<InteractionInfo> {
+    const row = await tables.UserInteractions.findOne({
+        where: { guild_id: guildId, user_id: userId },
+    });
+    if (!row) {
+        return { count: 0, tier: 'stranger', lastInteractionAt: null, hoursSinceLast: null };
+    }
+    const count = (row as any).interaction_count as number;
+    const lastAt = (row as any).last_interaction_at as Date;
+    const hoursSince = lastAt
+        ? Math.round((Date.now() - new Date(lastAt).getTime()) / 36e5)
+        : null;
+    return {
+        count,
+        tier: classifyTier(count),
+        lastInteractionAt: lastAt,
+        hoursSinceLast: hoursSince,
+    };
+}
+
+export async function bumpInteraction(
+    tables: Context['tables'],
+    guildId: string,
+    userId: string,
+): Promise<void> {
+    const now = new Date();
+    const [row, created] = await tables.UserInteractions.findOrCreate({
+        where: { guild_id: guildId, user_id: userId },
+        defaults: {
+            guild_id: guildId,
+            user_id: userId,
+            interaction_count: 1,
+            last_interaction_at: now,
+        },
+    });
+    if (!created) {
+        await (row as any).update({
+            interaction_count: (row as any).interaction_count + 1,
+            last_interaction_at: now,
+        });
+    }
+}
+
+export function describeRelationship(info: InteractionInfo, speakerName: string): string {
+    if (info.count === 0) {
+        return `You have never talked to ${speakerName} before. They're a stranger.`;
+    }
+    const parts = [
+        `Your relationship with ${speakerName}: ${info.tier} (${info.count} prior interactions).`,
+    ];
+    if (info.hoursSinceLast !== null && info.hoursSinceLast < 24) {
+        parts.push(`You talked with them ${info.hoursSinceLast}h ago.`);
+    }
+    if (info.tier === 'regular') {
+        parts.push('You know them well. Feel free to be warmer, reference past vibes.');
+    } else if (info.tier === 'stranger') {
+        parts.push('You barely know them. Keep some distance.');
+    }
+    return parts.join(' ');
+}

--- a/src/utils/assistant.ts
+++ b/src/utils/assistant.ts
@@ -9,6 +9,7 @@ import {
     getTimeOfDayBlock,
     Mood,
 } from './alia-mood';
+import { describeRelationship } from './alia-relationships';
 
 // OpenRouter provides an OpenAI-compatible API, so we reuse the openai SDK
 const openrouter = new OpenAI({
@@ -70,6 +71,30 @@ function buildMemoriesBlock(extras: AliaExtraContext | undefined): string | null
     return ['Relevant guild lore you remember:', ...lines].join('\n');
 }
 
+function buildRelationshipBlock(extras: AliaExtraContext | undefined, speakerName: string): string | null {
+    if (!extras) {return null;}
+    return describeRelationship(extras.relationship, speakerName);
+}
+
+function buildKnownUsersBlock(extras: AliaExtraContext | undefined): string | null {
+    if (!extras || extras.knownUsers.length === 0) {return null;}
+    const lines = extras.knownUsers.map(u => `- ${u.displayName} (id: ${u.userId})`);
+    return ['Users in this conversation (use these exact IDs with REMEMBER markers):', ...lines].join('\n');
+}
+
+const REMEMBER_INSTRUCTIONS = [
+    'Auto-learn capability:',
+    'If a user explicitly asks you to remember a fact about someone (themselves or',
+    'another person in the conversation), include a hidden marker in your reply:',
+    '  <REMEMBER user_id="<id>" description="<short phrase>"/>',
+    'Rules:',
+    '- Only use this when someone ASKS you to remember something. Do not invent facts.',
+    '- Use ONLY the exact Discord user IDs from the users-in-conversation list.',
+    '- The description should be a short phrase (e.g. "a badass guitarist"), not a sentence.',
+    '- The marker is stripped before Discord sees it. Still write your normal reply alongside.',
+    '- You can include multiple markers. One per fact.',
+].join('\n');
+
 function buildSystemPrompt(params: {
     mood: Mood;
     speakerName: string;
@@ -81,9 +106,12 @@ function buildSystemPrompt(params: {
         getMoodPromptBlock(mood),
         getTimeOfDayBlock(getTimeOfDay()),
         CORE_RULES_BLOCK,
+        buildRelationshipBlock(extras, speakerName),
         buildSpeakerBlock(extras, speakerName),
         buildMentionedBlock(extras),
         buildMemoriesBlock(extras),
+        buildKnownUsersBlock(extras),
+        REMEMBER_INSTRUCTIONS,
         COMMANDS_BLOCK,
     ];
     return blocks.filter((b): b is string => b !== null).join('\n\n');


### PR DESCRIPTION
## Summary
- Track per-guild-per-user interaction counts in a new `user_interactions` table; tier (stranger/acquaintance/regular) and time-since-last-chat are injected into Alia's system prompt so she's warmer to regulars and distant with strangers.
- Auto-learn: Alia emits hidden `<REMEMBER user_id="..." description="..."/>` markers when asked to remember facts; parser validates against the known-users set (speaker + @mentioned only), writes to `UserDescriptions` via `findOrCreate`, and strips markers before Discord sends.
- Every successful reply bumps the interaction counter.

## Test plan
- [ ] `npm run lint` clean
- [ ] `npx tsc --noEmit` clean
- [ ] Full jest suite passes (1509/1509 locally)
- [ ] Migration creates `user_interactions` table on deploy
- [ ] Manual: `Alia, remember Derek is a guitarist` → verify new row in `user_descriptions`, no marker leaks in the sent message
- [ ] Manual: attempt to spoof a fake user_id — rejected, logged as warn
- [ ] Manual: verify Alia's tone shifts between a new account (stranger) and a regular

🤖 Generated with [Claude Code](https://claude.com/claude-code)