### PR TITLE
fix(security): spam-shield dry-run works standalone with visible preview

### DIFF
--- a/src/utils/spam-shield.test.ts
+++ b/src/utils/spam-shield.test.ts
@@ -452,9 +452,13 @@ describe('executeShield', () => {
         );
     });
 
-    it('dry-run logs incident as dry_run without taking action', async () => {
+    it('dry-run logs incident as dry_run, posts preview, and takes no real action', async () => {
         const guild = buildGuild();
-        const trigger = buildMessage({ guild, userId: 'u1' });
+        const sourceSend = jest.fn().mockResolvedValue({});
+        const trigger = buildMessage({
+            guild, userId: 'u1', channelId: 'c2',
+            channel: { send: sourceSend },
+        });
         const ctx = buildContext({
             security_enabled_g1: 'true',
             security_dryrun_g1: 'true',
@@ -470,6 +474,27 @@ describe('executeShield', () => {
         expect(ctx.tables.SecurityIncidents.create).toHaveBeenCalledWith(
             expect.objectContaining({ action_taken: 'dry_run' }),
         );
+        expect(sourceSend).toHaveBeenCalledWith(expect.stringMatching(/dry-run/i));
+    });
+
+    it('dry-run alone (without enabled) still activates the shield', async () => {
+        const guild = buildGuild();
+        const sourceSend = jest.fn().mockResolvedValue({});
+        const trigger = buildMessage({
+            guild, userId: 'u1', channelId: 'c2',
+            channel: { send: sourceSend },
+        });
+        const ctx = buildContext({ security_dryrun_g1: 'true' });
+        const match = {
+            hash: 'h',
+            distinctChannelIds: new Set(['c1', 'c2']),
+            matchedEntries: [],
+        };
+        await executeShield(trigger, match as any, ctx);
+        expect(ctx.tables.SecurityIncidents.create).toHaveBeenCalledWith(
+            expect.objectContaining({ action_taken: 'dry_run' }),
+        );
+        expect(sourceSend).toHaveBeenCalled();
     });
 });
 

--- a/src/utils/spam-shield.ts
+++ b/src/utils/spam-shield.ts
@@ -182,7 +182,9 @@ export async function executeShield(
 
     try {
         const config = await loadShieldConfig(context, guildId);
-        if (!config.enabled) {
+        // Dry-run is a useful standalone state: log + visibly preview without
+        // requiring the shield to be fully armed. Either flag activates evaluation.
+        if (!config.enabled && !config.dryRun) {
             context.log.debug('Spam shield disabled for guild', { guildId });
             return;
         }
@@ -222,6 +224,17 @@ export async function executeShield(
             context.log.warn('Spam shield: dry-run trigger', {
                 userId, guildId, channels: [...match.distinctChannelIds],
             });
+            // Post a visible preview so admins can confirm the detector fires.
+            if (sourceChannel && 'send' in sourceChannel) {
+                const channelList = [...match.distinctChannelIds]
+                    .map(id => `<#${id}>`).join(', ');
+                await (sourceChannel as TextChannel).send(
+                    `[spam-shield dry-run] would have actioned <@${userId}> ` +
+                    `for duplicate content across ${channelList}.`,
+                ).catch(error => {
+                    context.log.warn('Spam shield: failed to post dry-run preview', { error });
+                });
+            }
             return;
         }
 


### PR DESCRIPTION
## Summary
- `executeShield` was gating on `config.enabled` first, so toggling only `shield-dryrun` was a silent no-op (real symptom in the wild: friend posted identical "wow" in 6 channels with dry-run on, nothing happened).
- Now either `enabled` or `dryRun` activates evaluation. When dry-run fires, we post a visible preview in the originating channel listing the user and the channels the duplicate was seen in, so admins can confirm the detector works before arming it for real.

## Test plan
- [ ] `npm run lint` clean
- [ ] `npx tsc --noEmit` clean
- [ ] `npx jest src/utils/spam-shield.test.ts` — 30 tests pass
- [ ] Manual: with only `shield-dryrun` set to true, post identical content from a test alt across two channels and verify the preview message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)