### PR TITLE
fix(security): precheck bot perms before spam-shield action and surface failures

### DIFF
--- a/src/utils/spam-shield.test.ts
+++ b/src/utils/spam-shield.test.ts
@@ -5,6 +5,7 @@ import {
     loadShieldConfig,
     executeShield,
     evaluateMessage,
+    precheckBotCanAction,
     _resetCacheForTests,
 } from './spam-shield';
 
@@ -14,6 +15,10 @@ jest.mock('./permissions', () => ({
 }));
 
 const { isOwner } = jest.requireMock('./permissions') as { isOwner: jest.Mock };
+
+const PERMS_OK = {
+    has: jest.fn().mockReturnValue(true),
+};
 
 function buildMessage(overrides: any = {}) {
     const { attachments, stickers, userId, ...rest } = overrides;
@@ -179,9 +184,14 @@ describe('executeShield', () => {
             permissions: { has: jest.fn().mockReturnValue(false) },
             roles: {
                 cache: buildRoleCache([{ id: 'r1' }, { id: 'r2' }]),
+                highest: { position: 1 },
                 set: jest.fn().mockResolvedValue(undefined),
             },
             timeout: jest.fn().mockResolvedValue(undefined),
+        };
+        const me = opts.me ?? {
+            permissions: PERMS_OK,
+            roles: { highest: { position: 100 } },
         };
         const purgatorySend = jest.fn().mockResolvedValue({});
         const purgatory = {
@@ -192,9 +202,10 @@ describe('executeShield', () => {
         channels.set('purg', purgatory);
         return {
             id: 'g1',
-            members: { fetch: jest.fn().mockResolvedValue(member) },
+            members: { fetch: jest.fn().mockResolvedValue(member), me },
             channels: { cache: channels },
             _member: member,
+            _me: me,
             _purgatorySend: purgatorySend,
         };
     }
@@ -305,39 +316,151 @@ describe('executeShield', () => {
         expect(cachedDelete).toHaveBeenCalled();
     });
 
-    it('logs an error but completes when role-strip fails', async () => {
+    it('on role-strip failure: still attempts timeout, posts diagnostic, skips all-clear', async () => {
         const guild = buildGuild();
-        guild._member.roles.set.mockRejectedValueOnce(new Error('discord 403'));
-        const trigger = buildMessage({ guild, userId: 'u1' });
-        const ctx = buildContext({ security_enabled_g1: 'true' });
+        guild._member.roles.set.mockRejectedValueOnce(new Error('Missing Permissions'));
+        const sourceSend = jest.fn().mockResolvedValue({});
+        const trigger = buildMessage({
+            guild, userId: 'u1', channel: { send: sourceSend },
+        });
+        const ctx = buildContext({
+            security_enabled_g1: 'true',
+            security_purgatory_channel_g1: 'purg',
+        });
         const match = {
             hash: 'h',
             distinctChannelIds: new Set(['c1', 'c2']),
             matchedEntries: [],
         };
+        const incidentRow = { update: jest.fn() };
+        ctx.tables.SecurityIncidents.create.mockResolvedValueOnce(incidentRow);
+
         await executeShield(trigger, match as any, ctx);
-        expect(ctx.log.error).toHaveBeenCalledWith(
-            expect.stringMatching(/strip roles/i),
-            expect.any(Object),
-        );
+
         expect(guild._member.timeout).toHaveBeenCalled();
+        expect(guild._purgatorySend).toHaveBeenCalledWith(expect.objectContaining({
+            content: expect.stringMatching(/partially failed/i),
+        }));
+        // No all-clear because we did not fully protect
+        expect(sourceSend).not.toHaveBeenCalledWith(expect.stringMatching(/protected/i));
+        expect(incidentRow.update).toHaveBeenCalledWith(expect.objectContaining({
+            action_taken: 'failed',
+        }));
     });
 
-    it('logs an error but completes when timeout fails', async () => {
+    it('on timeout failure: posts diagnostic, skips all-clear, marks failed', async () => {
         const guild = buildGuild();
-        guild._member.timeout.mockRejectedValueOnce(new Error('discord 403'));
-        const trigger = buildMessage({ guild, userId: 'u1' });
-        const ctx = buildContext({ security_enabled_g1: 'true' });
+        guild._member.timeout.mockRejectedValueOnce(new Error('Missing Permissions'));
+        const sourceSend = jest.fn().mockResolvedValue({});
+        const trigger = buildMessage({
+            guild, userId: 'u1', channel: { send: sourceSend },
+        });
+        const ctx = buildContext({
+            security_enabled_g1: 'true',
+            security_purgatory_channel_g1: 'purg',
+        });
         const match = {
             hash: 'h',
             distinctChannelIds: new Set(['c1', 'c2']),
             matchedEntries: [],
         };
+        const incidentRow = { update: jest.fn() };
+        ctx.tables.SecurityIncidents.create.mockResolvedValueOnce(incidentRow);
+
         await executeShield(trigger, match as any, ctx);
-        expect(ctx.log.error).toHaveBeenCalledWith(
-            expect.stringMatching(/timeout/i),
-            expect.any(Object),
+
+        expect(guild._purgatorySend).toHaveBeenCalledWith(expect.objectContaining({
+            content: expect.stringMatching(/partially failed/i),
+        }));
+        expect(sourceSend).not.toHaveBeenCalledWith(expect.stringMatching(/protected/i));
+        expect(incidentRow.update).toHaveBeenCalledWith(expect.objectContaining({
+            action_taken: 'failed',
+        }));
+    });
+
+    it('precheck blocks action when bot role is below target role', async () => {
+        const guild = buildGuild({
+            me: {
+                permissions: PERMS_OK,
+                roles: { highest: { position: 1 } },
+            },
+            member: {
+                id: 'u1',
+                permissions: { has: jest.fn().mockReturnValue(false) },
+                roles: {
+                    cache: buildRoleCache([{ id: 'r1' }]),
+                    highest: { position: 50 },
+                    set: jest.fn(),
+                },
+                timeout: jest.fn(),
+            },
+        });
+        const trigger = buildMessage({ guild, userId: 'u1' });
+        const ctx = buildContext({
+            security_enabled_g1: 'true',
+            security_purgatory_channel_g1: 'purg',
+        });
+        const match = {
+            hash: 'h',
+            distinctChannelIds: new Set(['c1', 'c2']),
+            matchedEntries: [],
+        };
+        const incidentRow = { update: jest.fn() };
+        ctx.tables.SecurityIncidents.create.mockResolvedValueOnce(incidentRow);
+
+        await executeShield(trigger, match as any, ctx);
+
+        expect(guild._member.roles.set).not.toHaveBeenCalled();
+        expect(guild._member.timeout).not.toHaveBeenCalled();
+        expect(guild._purgatorySend).toHaveBeenCalledWith(expect.objectContaining({
+            content: expect.stringMatching(/highest role.*not above/i),
+        }));
+        expect(incidentRow.update).toHaveBeenCalledWith(expect.objectContaining({
+            action_taken: 'failed',
+        }));
+    });
+
+    it('precheck blocks action when bot lacks ManageRoles', async () => {
+        const guild = buildGuild({
+            me: {
+                permissions: { has: jest.fn().mockImplementation(() => false) },
+                roles: { highest: { position: 100 } },
+            },
+        });
+        const trigger = buildMessage({ guild, userId: 'u1' });
+        const ctx = buildContext({
+            security_enabled_g1: 'true',
+            security_purgatory_channel_g1: 'purg',
+        });
+        const match = {
+            hash: 'h',
+            distinctChannelIds: new Set(['c1', 'c2']),
+            matchedEntries: [],
+        };
+        const incidentRow = { update: jest.fn() };
+        ctx.tables.SecurityIncidents.create.mockResolvedValueOnce(incidentRow);
+
+        await executeShield(trigger, match as any, ctx);
+
+        expect(guild._member.roles.set).not.toHaveBeenCalled();
+        expect(guild._purgatorySend).toHaveBeenCalledWith(expect.objectContaining({
+            content: expect.stringMatching(/Manage Roles/i),
+        }));
+    });
+
+    it('precheckBotCanAction returns ok when permissions and hierarchy are correct', () => {
+        const result = precheckBotCanAction(
+            {
+                members: {
+                    me: {
+                        permissions: PERMS_OK,
+                        roles: { highest: { position: 100 } },
+                    },
+                },
+            },
+            { roles: { highest: { position: 5 } } },
         );
+        expect(result.ok).toBe(true);
     });
 
     it('skips when an action lock is already held for the same user', async () => {
@@ -518,6 +641,10 @@ describe('evaluateMessage (integration)', () => {
         const guild = {
             id: 'g1',
             members: {
+                me: {
+                    permissions: { has: jest.fn().mockReturnValue(true) },
+                    roles: { highest: { position: 100 } },
+                },
                 fetch: jest.fn().mockResolvedValue({
                     id: 'u1',
                     permissions: { has: jest.fn().mockReturnValue(false) },
@@ -525,6 +652,7 @@ describe('evaluateMessage (integration)', () => {
                         cache: {
                             filter: () => ({ map: () => [] }),
                         },
+                        highest: { position: 1 },
                         set: jest.fn().mockResolvedValue(undefined),
                     },
                     timeout: jest.fn().mockResolvedValue(undefined),

--- a/src/utils/spam-shield.ts
+++ b/src/utils/spam-shield.ts
@@ -163,6 +163,51 @@ async function safelyDelete(message: Message, context: Context): Promise<void> {
     }
 }
 
+interface PrecheckResult {
+    ok: boolean;
+    reason?: string;
+}
+
+/**
+ * Verifies the bot has the permissions and role-hierarchy position needed to
+ * strip the target's roles and apply a timeout. Surfaces the specific reason
+ * if not, so admins can fix the misconfiguration instead of debugging silent
+ * failures.
+ */
+export function precheckBotCanAction(
+    guild: any,
+    target: any,
+): PrecheckResult {
+    const me = guild.members?.me;
+    if (!me) {return { ok: false, reason: "couldn't resolve my own guild member record" };}
+
+    const perms = me.permissions;
+    if (!perms?.has(PermissionFlagsBits.ManageRoles)) {
+        return { ok: false, reason: 'I am missing the **Manage Roles** permission' };
+    }
+    if (!perms.has(PermissionFlagsBits.ModerateMembers)) {
+        return { ok: false, reason: 'I am missing the **Timeout Members** permission' };
+    }
+
+    const myTop = me.roles?.highest?.position ?? 0;
+    const targetTop = target.roles?.highest?.position ?? 0;
+    if (targetTop >= myTop) {
+        return {
+            ok: false,
+            reason: 'my highest role is **not above** the target user\'s highest role ' +
+                '(Discord blocks role/timeout actions on equal-or-higher members)',
+        };
+    }
+
+    return { ok: true };
+}
+
+function errorMessage(error: unknown): string {
+    if (error instanceof Error) {return error.message;}
+    if (typeof error === 'string') {return error;}
+    return 'unknown error';
+}
+
 export async function executeShield(
     triggerMessage: Message,
     match: DuplicateMatch,
@@ -238,6 +283,39 @@ export async function executeShield(
             return;
         }
 
+        const purgatoryChannel = config.purgatoryChannelId
+            ? guild.channels.cache.get(config.purgatoryChannelId)
+            : null;
+        const adminChannel = (purgatoryChannel && (purgatoryChannel as any).isTextBased?.())
+            ? (purgatoryChannel as TextChannel)
+            : (sourceChannel && 'send' in sourceChannel ? sourceChannel as TextChannel : null);
+
+        // 0. Precheck: verify bot can actually act on this member. Surface the
+        //    real reason if not, so admins can fix the config.
+        const precheck = precheckBotCanAction(guild, member);
+        if (!precheck.ok) {
+            const note = `🚨 Spam shield detected duplicate from <@${userId}> ` +
+                `but **could not action them**: ${precheck.reason}.`;
+            if (adminChannel) {
+                await adminChannel.send({
+                    content: note,
+                    allowedMentions: { users: [] },
+                }).catch(error => {
+                    context.log.warn('Spam shield: failed to post precheck failure', { error });
+                });
+            }
+            await (incident as any).update({
+                action_taken: 'failed',
+                details: JSON.stringify({ stage: 'precheck', reason: precheck.reason }),
+            });
+            context.log.error('Spam shield: precheck failed', {
+                userId, guildId, reason: precheck.reason,
+            });
+            return;
+        }
+
+        const failures: string[] = [];
+
         // 1. Bulk-delete the spam messages (the new + the cached previous occurrences).
         await safelyDelete(triggerMessage, context);
         for (const entry of match.matchedEntries) {
@@ -255,39 +333,49 @@ export async function executeShield(
         }
 
         // 2. Strip all (manageable) roles.
+        let rolesStripped = false;
         try {
             await member!.roles.set([], 'Spam shield: cross-channel duplicate spam');
+            rolesStripped = true;
         } catch (error) {
+            const msg = `role strip failed: ${errorMessage(error)}`;
+            failures.push(msg);
             context.log.error('Spam shield: failed to strip roles', {
                 error, userId, guildId,
             });
         }
 
         // 3. Timeout 24h.
+        let timedOut = false;
         try {
             await member!.timeout(TIMEOUT_DURATION_MS, 'Spam shield: cross-channel duplicate spam');
+            timedOut = true;
         } catch (error) {
+            const msg = `timeout failed: ${errorMessage(error)}`;
+            failures.push(msg);
             context.log.error('Spam shield: failed to timeout member', {
                 error, userId, guildId,
             });
         }
 
-        // 4. Post Dune-flavored warning in purgatory channel.
-        if (config.purgatoryChannelId) {
-            const purgatory = guild.channels.cache.get(config.purgatoryChannelId);
-            if (purgatory && purgatory.isTextBased()) {
-                const warning = pickDuneWarning();
-                await (purgatory as TextChannel).send({
-                    content: `<@${userId}> — ${warning}`,
-                    allowedMentions: { users: [userId] },
-                }).catch(error => {
-                    context.log.warn('Spam shield: failed to post purgatory warning', { error });
-                });
-            }
+        const fullySucceeded = rolesStripped && timedOut;
+
+        // 4. Post warning in purgatory: Dune flavor on success, diagnostic on partial.
+        if (purgatoryChannel && (purgatoryChannel as any).isTextBased?.()) {
+            const warning = fullySucceeded
+                ? `<@${userId}> — ${pickDuneWarning()}`
+                : `🚨 Spam shield triggered for <@${userId}> but **partially failed**:\n` +
+                    failures.map(f => `- ${f}`).join('\n');
+            await (purgatoryChannel as TextChannel).send({
+                content: warning,
+                allowedMentions: { users: fullySucceeded ? [userId] : [] },
+            }).catch(error => {
+                context.log.warn('Spam shield: failed to post purgatory warning', { error });
+            });
         }
 
-        // 5. Post all-clear in the originating channel.
-        if (sourceChannel && 'send' in sourceChannel) {
+        // 5. Post all-clear ONLY if we actually protected the server.
+        if (fullySucceeded && sourceChannel && 'send' in sourceChannel) {
             await (sourceChannel as TextChannel).send(
                 "I've protected the server from spam, again.",
             ).catch(error => {
@@ -295,11 +383,14 @@ export async function executeShield(
             });
         }
 
-        await (incident as any).update({ action_taken: 'actioned' });
+        await (incident as any).update({
+            action_taken: fullySucceeded ? 'actioned' : 'failed',
+            details: failures.length > 0 ? JSON.stringify({ failures }) : null,
+        });
 
-        context.log.info('Spam shield: actioned compromised account', {
+        context.log.info('Spam shield: action sequence complete', {
             userId, guildId, channels: [...match.distinctChannelIds],
-            rolesStripped: rolesSnapshot.length,
+            rolesStripped, timedOut, failures,
         });
     } catch (error) {
         context.log.error('Spam shield: execution failed', { error, key });


### PR DESCRIPTION
## Summary
- Reported: shield enabled in prod, friend posted duplicate, Dune warning landed in purgatory but user kept all roles and was never timed out. Caused by silent try/catch around `member.roles.set([])` and `member.timeout()` — and the all-clear posted unconditionally, masking the failure.
- New `precheckBotCanAction` verifies Manage Roles + Timeout Members perms and that the bot's highest role is above the target's before action; surfaces the specific reason to admins if not.
- `roles.set` / `timeout` failures now collect real error messages, post a "partially failed" diagnostic in purgatory, skip the all-clear, and mark the incident `failed` with a `details` JSON payload.

## Test plan
- [ ] `npm run lint` clean
- [ ] `npx tsc --noEmit` clean
- [ ] `npx jest src/utils/spam-shield.test.ts` — 33 tests pass
- [ ] On deploy: re-run the original repro scenario; expect either real action or a clear admin-visible reason in #purgatory

🤖 Generated with [Claude Code](https://claude.com/claude-code)