### PR TITLE
fix(assistant): restore Alia by replacing removed Grok model

### DIFF
--- a/src/responses/assistant.test.ts
+++ b/src/responses/assistant.test.ts
@@ -27,6 +27,8 @@ import assistantResponse from './assistant';
 import generateResponse from '../utils/assistant';
 import { safelySendToChannel } from '../utils/discordHelpers';
 import { _resetForTests as resetHistory } from '../utils/conversation-history';
+import { gatherAliaContext } from '../utils/alia-context';
+import { bumpInteraction } from '../utils/alia-relationships';
 
 // Mock openai SDK (used by OpenRouter client) to prevent instantiation errors
 jest.mock('openai', () => ({
@@ -347,6 +349,68 @@ describe('Assistant Response System', () => {
 
                 expect(result).toBe(false);
             });
+        });
+    });
+
+    describe('Auto-learn and Interaction Tracking', () => {
+        beforeEach(() => {
+            mockMessage.content = 'Alia, remember that Bob is a cool dude';
+            (mockMessage as any).guildId = 'test-guild-id';
+        });
+
+        it('persists REMEMBER markers and sends the cleaned reply', async () => {
+            (gatherAliaContext as jest.Mock).mockResolvedValueOnce({
+                speakerDescriptions: [],
+                mentionedUsers: [],
+                relevantMemories: [],
+                history: [],
+                relationship: {
+                    count: 0, tier: 'stranger', lastInteractionAt: null, hoursSinceLast: null,
+                },
+                knownUsers: [{ userId: '999', displayName: 'Bob' }],
+            });
+            const findOrCreate = jest.fn().mockResolvedValue([{}, true]);
+            (mockContext as any).tables = { UserDescriptions: { findOrCreate } };
+            mockGenerateResponse.mockResolvedValue(
+                'Noted! <REMEMBER user_id="999" description="a cool dude"/>',
+            );
+
+            const result = await assistantResponse(mockMessage as Message, mockContext);
+
+            expect(result).toBe(true);
+            expect(findOrCreate).toHaveBeenCalled();
+            expect(mockContext.log.info).toHaveBeenCalledWith(
+                'Auto-learn persisted markers',
+                expect.objectContaining({ attempted: 1, saved: 1 }),
+            );
+            // Marker is stripped before the reply reaches Discord.
+            expect(mockSafelySendToChannel).toHaveBeenCalledWith(
+                mockChannel,
+                'Noted!',
+                mockContext,
+                'assistant response',
+            );
+        });
+
+        it('bumps the interaction count after a successful reply', async () => {
+            const result = await assistantResponse(mockMessage as Message, mockContext);
+
+            expect(result).toBe(true);
+            expect(bumpInteraction).toHaveBeenCalledWith(
+                undefined, 'test-guild-id', 'test-user-id',
+            );
+        });
+
+        it('logs a warning when bumping the interaction count fails', async () => {
+            (bumpInteraction as jest.Mock).mockRejectedValueOnce(new Error('db down'));
+
+            const result = await assistantResponse(mockMessage as Message, mockContext);
+
+            expect(result).toBe(true);
+            expect(mockContext.log.warn).toHaveBeenCalledWith(
+                'Failed to bump interaction count',
+                expect.objectContaining({ error: expect.any(Error) }),
+            );
         });
     });
 });

--- a/src/utils/assistant.ts
+++ b/src/utils/assistant.ts
@@ -151,7 +151,7 @@ async function generateResponse(
         const historyMessages = buildHistoryMessages(extras);
 
         const requestData = {
-            model: 'x-ai/grok-3-mini-beta',
+            model: 'x-ai/grok-4.3',
             messages: [
                 { role: 'system' as const, content: systemPrompt },
                 ...historyMessages,
@@ -248,7 +248,7 @@ async function generateResponse(
         }
 
         Sentry.captureException(error, {
-            tags: { feature: 'assistant', provider: 'openrouter', model: 'grok-3-mini-beta' },
+            tags: { feature: 'assistant', provider: 'openrouter', model: 'grok-4.3' },
             extra: errorData,
         });
 


### PR DESCRIPTION
## Summary

- `@alia` stopped responding because OpenRouter removed `x-ai/grok-3-mini-beta`; every request 404'd and `generateResponse` silently returned `null`. This was not a credits issue — reloading OpenRouter could not fix a model-not-found error.
- Switches the assistant to `x-ai/grok-4.3` (currently available; same $1.25/$2.50 per-M pricing) and updates the Sentry error tag to match.
- **Note:** `master` was 19 commits stale, so this PR also rolls up the backlogged Alia personality overhaul, stock tracking, and spam-shield work. The model fix itself is the single commit `243890f`.

## Test plan

- [x] `npx jest src/responses/assistant.test.ts` — 24/24 pass
- [x] `npx tsc --noEmit` — no new errors from this change
- [x] Verified `x-ai/grok-4.3` is present in the live OpenRouter `/models` list
- [ ] After deploy: `@alia <question>` returns a reply in Discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)