### PR TITLE
feat(adlibs): use ^^^ placeholder and delete triggering message

### DIFF
--- a/src/commands/adlibs.ts
+++ b/src/commands/adlibs.ts
@@ -1,7 +1,7 @@
 // Description:
-//   You are a ---.
-//   So --- maybe you should ---,
-//   but perhaps ---.
+//   You are a ^^^.
+//   So ^^^ maybe you should ^^^,
+//   but perhaps ^^^.
 //
 // Dependencies:
 //   None

--- a/src/responses/adlibs.test.ts
+++ b/src/responses/adlibs.test.ts
@@ -7,8 +7,9 @@ describe('response/adlibs', () => {
     beforeEach(() => {
         context = createContext();
         message = {
-            content: 'The --- walks in.',
+            content: 'The ^^^ walks in.',
             channel: { send: jest.fn() },
+            delete: jest.fn(),
         };
         Adlibs = createTable();
         context.tables = { Adlibs };
@@ -18,11 +19,12 @@ describe('response/adlibs', () => {
         Adlibs.findOne.mockResolvedValue({ value: 'cat' });
         const result = await adlibs(message, context);
         expect(message.channel.send).toBeCalledWith('The **cat** walks in.');
+        expect(message.delete).toHaveBeenCalled();
         expect(result).toBe(true);
     });
 
     it('responds should match multiple words', async () => {
-        message.content = 'The ---, ---, and --- ran by.';
+        message.content = 'The ^^^, ^^^, and ^^^ ran by.';
         Adlibs.findOne = jest
             .fn()
             .mockResolvedValueOnce({ value: 'dog' })
@@ -39,6 +41,7 @@ describe('response/adlibs', () => {
         message.content = 'regular text';
         const result = await adlibs(message, context);
         expect(message.channel.send).not.toHaveBeenCalled();
+        expect(message.delete).not.toHaveBeenCalled();
         expect(result).toBe(false);
     });
 
@@ -47,5 +50,6 @@ describe('response/adlibs', () => {
         const result = await adlibs(message, context);
         expect(result).toBe(false);
         expect(message.channel.send).not.toHaveBeenCalled();
+        expect(message.delete).not.toHaveBeenCalled();
     });
 });

--- a/src/responses/adlibs.ts
+++ b/src/responses/adlibs.ts
@@ -3,7 +3,7 @@ import Sequelize from "sequelize";
 export default async (message: any, { tables, log }: any): Promise<boolean> => {
     const { Adlibs } = tables;
     let response = message.content;
-    const regex = /(-{3,})+/g;
+    const regex = /(\^{3,})+/g;
     if (regex.test(response)) {
         try {
             const matches = response.match(regex);
@@ -22,6 +22,8 @@ export default async (message: any, { tables, log }: any): Promise<boolean> => {
             );
 
             await message.channel.send(response);
+            // Delete the original message to hide who triggered the adlib.
+            await message.delete();
             return true; // Successfully processed Adlibs message
         } catch (error) {
             log.error('Adlibs response failed:', { error });


### PR DESCRIPTION
## Summary
- Switch the adlibs auto-response trigger from `---` to `^^^` (3+ carets)
- Delete the original message after responding, hiding who triggered the adlib
- Update header doc example and tests (assert delete is/ isn't called)

## Test plan
- `npx jest src/responses/adlibs.test.ts` — 4/4 pass
- `npx eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)