### PR TITLE
Add natural-language "@user is ..." description capture

### DIFF
--- a/events/messageCreate.ts
+++ b/events/messageCreate.ts
@@ -60,6 +60,22 @@ const messageCreateEvent: BotEvent = {
                 }
             }
 
+            // 1.5. High Priority: Descriptions ("@user is ..." natural-language capture)
+            if (!responseHandled) {
+                try {
+                    const descriptionsResult = await response.Descriptions(message, context);
+                    if (descriptionsResult === true) { // Description captured
+                        responseHandled = true;
+                        context.log.debug('Message handled by Descriptions', {
+                            messageId: message.id,
+                            userId: message.author.id,
+                        });
+                    }
+                } catch (error) {
+                    context.log.error('Descriptions response failed', { error });
+                }
+            }
+
             // 2. High Priority: Assistant (NLP Questions)
             if (!responseHandled) {
                 try {

--- a/src/responses/descriptions.test.ts
+++ b/src/responses/descriptions.test.ts
@@ -1,0 +1,137 @@
+import { createContext, createTable } from "../utils/testHelpers";
+import descriptions, { parseDescription } from "./descriptions";
+
+describe('response/descriptions', () => {
+    let context: any;
+    let message: any;
+    let mockReact: jest.Mock;
+    let UserDescriptions: ReturnType<typeof createTable>;
+
+    const buildMessage = (overrides: Record<string, unknown> = {}) => ({
+        content: '<@111222333> is a badass guitarist',
+        author: { id: 'creator-456', bot: false },
+        guildId: 'guild-123',
+        id: 'msg-123',
+        inGuild: () => true,
+        mentions: { users: new Map([['111222333', { id: '111222333' }]]) },
+        react: mockReact,
+        ...overrides,
+    });
+
+    beforeEach(() => {
+        context = createContext();
+        UserDescriptions = createTable();
+        context.tables.UserDescriptions = UserDescriptions;
+        mockReact = jest.fn().mockResolvedValue(undefined);
+        message = buildMessage();
+    });
+
+    describe('parseDescription', () => {
+        it('parses a "@user is ..." message', () => {
+            expect(parseDescription(buildMessage() as never)).toEqual({
+                userId: '111222333',
+                description: 'a badass guitarist',
+            });
+        });
+
+        it('strips a trailing period', () => {
+            const result = parseDescription(buildMessage({ content: '<@111222333> is cool.' }) as never);
+            expect(result).toEqual({ userId: '111222333', description: 'cool' });
+        });
+
+        it('ignores messages from bots', () => {
+            expect(parseDescription(buildMessage({ author: { id: 'x', bot: true } }) as never)).toBeNull();
+        });
+
+        it('ignores messages outside a guild', () => {
+            expect(parseDescription(buildMessage({ inGuild: () => false }) as never)).toBeNull();
+        });
+
+        it('ignores plain text without a real mention', () => {
+            const result = parseDescription(buildMessage({
+                content: 'bones is cute',
+                mentions: { users: new Map() },
+            }) as never);
+            expect(result).toBeNull();
+        });
+
+        it('ignores a mention that is not actually a server mention', () => {
+            const result = parseDescription(buildMessage({
+                mentions: { users: new Map() },
+            }) as never);
+            expect(result).toBeNull();
+        });
+
+        it('ignores questions', () => {
+            const result = parseDescription(buildMessage({ content: '<@111222333> is cute?' }) as never);
+            expect(result).toBeNull();
+        });
+
+        it('ignores overly long descriptions', () => {
+            const long = 'x'.repeat(201);
+            expect(parseDescription(buildMessage({ content: `<@111222333> is ${long}` }) as never)).toBeNull();
+        });
+
+        it('ignores "@user is" with no description', () => {
+            const result = parseDescription(buildMessage({ content: '<@111222333> is   ' }) as never);
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('capture handler', () => {
+        it('stores a new description and reacts', async () => {
+            UserDescriptions.findOne.mockResolvedValue(null);
+            UserDescriptions.create.mockResolvedValue({});
+
+            const result = await descriptions(message, context);
+
+            expect(result).toBe(true);
+            expect(UserDescriptions.create).toHaveBeenCalledWith({
+                guild_id: 'guild-123',
+                user_id: '111222333',
+                description: 'a badass guitarist',
+                creator_id: 'creator-456',
+            });
+            expect(mockReact).toHaveBeenCalledWith('📝');
+        });
+
+        it('does not duplicate an existing description but still reacts', async () => {
+            UserDescriptions.findOne.mockResolvedValue({ id: 1 });
+
+            const result = await descriptions(message, context);
+
+            expect(result).toBe(true);
+            expect(UserDescriptions.create).not.toHaveBeenCalled();
+            expect(mockReact).toHaveBeenCalledWith('📝');
+        });
+
+        it('returns false for non-description messages', async () => {
+            message = buildMessage({ content: 'hello everyone' });
+
+            const result = await descriptions(message, context);
+
+            expect(result).toBe(false);
+            expect(UserDescriptions.findOne).not.toHaveBeenCalled();
+            expect(mockReact).not.toHaveBeenCalled();
+        });
+
+        it('still succeeds if reacting fails', async () => {
+            UserDescriptions.findOne.mockResolvedValue(null);
+            UserDescriptions.create.mockResolvedValue({});
+            mockReact.mockRejectedValue(new Error('missing perms'));
+
+            const result = await descriptions(message, context);
+
+            expect(result).toBe(true);
+        });
+
+        it('returns false and logs when the database errors', async () => {
+            UserDescriptions.findOne.mockRejectedValue(new Error('db down'));
+
+            const result = await descriptions(message, context);
+
+            expect(result).toBe(false);
+            expect(context.log.error).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/responses/descriptions.ts
+++ b/src/responses/descriptions.ts
@@ -1,0 +1,96 @@
+import { Message } from 'discord.js';
+import { Context } from '../types';
+
+// Matches a message that opens with a user mention followed by "is", e.g.
+// "@user is cute". Group 1 = user id, group 2 = the description.
+const DESCRIPTION_REGEX = /^\s*<@!?(\d+)>\s+is\s+(.+)$/i;
+
+// Descriptions longer than this are ignored (the model column is STRING(255);
+// 200 keeps a safety margin and mirrors the mercy-bot behaviour).
+const MAX_DESCRIPTION_LENGTH = 200;
+
+/**
+ * Parses a "@user is <something>" message into a subject and description, or
+ * null if it isn't one. Requires a real user mention (a plain name like
+ * "bones is cute" is ignored), and skips questions and overly long text.
+ */
+export function parseDescription(
+    message: Message,
+): { userId: string; description: string } | null {
+    if (message.author.bot || !message.inGuild()) {
+        return null;
+    }
+
+    const match = message.content.match(DESCRIPTION_REGEX);
+    if (!match) {
+        return null;
+    }
+
+    const [, userId, rawDescription] = match;
+    if (!message.mentions.users.has(userId)) {
+        return null;
+    }
+
+    const description = rawDescription.trim().replace(/\.\s*$/, '');
+    if (!description || description.endsWith('?') || description.length > MAX_DESCRIPTION_LENGTH) {
+        return null;
+    }
+
+    return { userId, description };
+}
+
+/**
+ * Natural-language capture for descriptions. When someone types
+ * "@user is <something>" the description is stored (shared with the /is
+ * command) and the message is acknowledged with a 📝 reaction.
+ *
+ * Returns true if the message was a description and was handled.
+ */
+export default async (message: Message, context: Context): Promise<boolean> => {
+    const { tables, log } = context;
+
+    try {
+        const parsed = parseDescription(message);
+        if (!parsed || !message.guildId) {
+            return false;
+        }
+
+        // Skip if this exact description already exists for the user (the model
+        // has a unique index, but checking first avoids noisy duplicate errors).
+        const existing = await tables.UserDescriptions.findOne({
+            where: {
+                guild_id: message.guildId,
+                user_id: parsed.userId,
+                description: parsed.description,
+            },
+        });
+
+        if (!existing) {
+            await tables.UserDescriptions.create({
+                guild_id: message.guildId,
+                user_id: parsed.userId,
+                description: parsed.description,
+                creator_id: message.author.id,
+            });
+        }
+
+        // Acknowledge with a reaction rather than a chat reply, so capture stays
+        // quiet. Failures (missing perms, deleted message) are non-fatal.
+        await message.react('📝').catch(() => {});
+
+        log.debug('Description captured from message', {
+            messageId: message.id,
+            userId: parsed.userId,
+            creatorId: message.author.id,
+            duplicate: Boolean(existing),
+        });
+
+        return true;
+    } catch (error) {
+        log.error('Descriptions response failed:', { error });
+        return false;
+    }
+};
+
+// Export for testing
+export { DESCRIPTION_REGEX, MAX_DESCRIPTION_LENGTH };

--- a/src/responses/index.ts
+++ b/src/responses/index.ts
@@ -6,6 +6,7 @@ import Dnd from "./dnd";
 import Tips from "./tips";
 import Password from "./password";
 import Greetings from "./greetings";
+import Descriptions from "./descriptions";
 
 export default {
     Adlibs,
@@ -16,4 +17,5 @@ export default {
     Tips,
     Password,
     Greetings,
+    Descriptions,
 };


### PR DESCRIPTION
## Summary
Brings the `/is` system in line with the `is` system from mercy-bot. The headline change is **natural-language capture**: typing `@user is <something>` in chat now stores the description and acknowledges with a 📝 reaction — no `/is add` required. The existing `/is add/remove/who` command is left fully intact.

## Changes
- **`src/responses/descriptions.ts`** — new message response handler:
  - Parses `@user is X` messages (requires a real numeric-ID mention).
  - Stores via the existing `UserDescriptions` model, so captures also surface in `/is who`.
  - Skips bots, DMs, questions (`?`), empty text, and anything over 200 chars; strips a trailing period; de-dupes against existing entries.
  - Reacts 📝 instead of replying in chat.
- **`src/responses/index.ts`** — registered the `Descriptions` handler.
- **`events/messageCreate.ts`** — wired into the priority chain after D&D and **before** Assistant, so `@user is …` isn't routed to OpenAI.

## Behavior
- **Capture (new):** `@somebody is a badass guitarist` → stored, 📝 reaction.
- **Lookup:** `/is who @somebody` → unchanged, now includes captured entries.
- **Add/remove:** `/is add`, `/is remove` unchanged.

## Notes
- Capture caps at 200 chars (mercy-bot's value); the column allows 255 and `/is add` still allows the full 255.
- Storage uses alia-bot's existing Sequelize `UserDescriptions` model (no schema change).

## Testing
- New `src/responses/descriptions.test.ts` (14 cases) — all pass.
- ESLint and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)